### PR TITLE
chore: change marketplace source from local to GitHub

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,15 +6,15 @@
         "repo": "anthropics/claude-code"
       }
     },
-    "kokuyouwind-plugins-local": {
+    "kokuyouwind-plugins": {
       "source": {
-        "source": "local",
-        "path": "/Users/kokuyouwind/repos/claude-plugins"
+        "source": "github",
+        "repo": "kokuyouwind/claude-plugins"
       }
     }
   },
   "enabledPlugins": [
     "plugin-dev@claude-code-plugins",
-    "dev-guidelines@kokuyouwind-plugins-local"
+    "dev-guidelines@kokuyouwind-plugins"
   ]
 }


### PR DESCRIPTION
- Update kokuyouwind-plugins-local to kokuyouwind-plugins
- Change source from local path to GitHub repository
- Enable installation from GitHub instead of local directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)