### PR TITLE
fix: correct enabledPlugins format from array to object

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,8 +13,8 @@
       }
     }
   },
-  "enabledPlugins": [
-    "plugin-dev@claude-code-plugins",
-    "dev-guidelines@kokuyouwind-plugins"
-  ]
+  "enabledPlugins": {
+    "plugin-dev@claude-code-plugins": true,
+    "dev-guidelines@kokuyouwind-plugins": true
+  }
 }


### PR DESCRIPTION
## 概要
`.claude/settings.json`の`enabledPlugins`フィールドを配列形式からオブジェクト形式に修正しました。

## 変更内容
- `enabledPlugins`を配列形式 (`["plugin-dev@claude-code-plugins", ...]`) からオブジェクト形式 (`{"plugin-dev@claude-code-plugins": true, ...}`) に変更
- Claude Code の正しい仕様に準拠

## 動作確認
- [ ] settings.jsonの書式が正しいことを確認
- [ ] プラグインが正常に読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)