### PR TITLE
feat: Issue自動解決workflowの追加

### DIFF
--- a/.github/workflows/claude-issue-auto-resolver.yml
+++ b/.github/workflows/claude-issue-auto-resolver.yml
@@ -1,0 +1,48 @@
+name: Claude Issue Auto-resolver
+
+on:
+  schedule:
+    # JST 1:00~7:00 = UTC 16:00~22:00 (every hour)
+    - cron: '0 16,17,18,19,20,21,22 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  resolve-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Find and comment on unresolved issue
+        env:
+          # Use Personal Access Token as GitHub App tokens don't trigger claude-code-action
+          GH_TOKEN: ${{ secrets.GITHUB_PAT }}
+        run: |
+          # Search for issues in priority order: high -> medium -> low
+          for priority in "priority:high" "priority:medium" "priority:low"; do
+            echo "Searching for issues with label: $priority"
+
+            # Find unresolved issues (without claude-code-requested label)
+            issue=$(gh issue list --repo ${{ github.repository }} \
+              --label "$priority" \
+              --state open \
+              --json number,labels,createdAt \
+              --jq '[.[] | select(.labels | map(.name) | contains(["claude-code-requested"]) | not)] | sort_by(.createdAt) | reverse | .[0].number')
+
+            if [ -n "$issue" ] && [ "$issue" != "null" ]; then
+              echo "Found issue #$issue with $priority"
+
+              # Post a comment mentioning @claude
+              gh issue comment $issue --repo ${{ github.repository }} \
+                --body "@claude この問題を解決してください"
+
+              # Add claude-code-requested label to prevent duplicate processing
+              gh issue edit $issue --repo ${{ github.repository }} \
+                --add-label "claude-code-requested"
+
+              echo "Successfully commented on issue #$issue and added label"
+              exit 0
+            fi
+          done
+
+          echo "No unresolved issues found with priority labels"


### PR DESCRIPTION
## 概要
夜間にIssueを自動的に検出し、Claudeに解決を依頼するGitHub Actions workflowを追加しました。

## 変更の背景
Issueの対応を自動化するため、定期的にIssueをチェックして優先度順に処理するworkflowが必要でした。https://zenn.dev/r_kaga/articles/731fe4636289dc の記事を参考に、夜間の自動解決システムを実装しました。

## 変更詳細
- `.github/workflows/claude-issue-auto-resolver.yml` を新規作成
- 実行スケジュール: JST 1:00~7:00の間、1時間ごとに実行（UTC 16:00~22:00）
- Issue検索ロジック: `priority:high` → `priority:medium` → `priority:low` の順で未処理のIssueを検索
- 自動コメント機能: 見つかったIssueに「@claude この問題を解決してください」とコメント
- 重複処理防止: `claude-code-requested` ラベルを付与して、同じIssueへの重複処理を防止
- 手動実行サポート: `workflow_dispatch` により、GitHub Actions UIから手動実行が可能

## 動作に必要な設定
このworkflowを動作させるには、Personal Access Token（PAT）の設定が必要です：
1. GitHub Personal Access Token (classic) を `repo` スコープで作成
2. リポジトリのSecrets設定で `GITHUB_PAT` という名前で登録

※GitHub App tokenではclaude-code-actionがトリガーされないため、PATが必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)