### PR TITLE
feat: Extract RBS documentation into auto-activating skills

### DIFF
--- a/plugins/rbs-goose/commands/setup.md
+++ b/plugins/rbs-goose/commands/setup.md
@@ -5,6 +5,14 @@ Follow these instructions:
 # (e.g., ~/.claude/plugins/marketplaces/kokuyouwind-plugins/plugins/rbs-goose)
 plugin_base_path = File.dirname(__FILE__) # This is the plugin root directory
 
+# Note: Documentation for RBS, Steep, and related tools is available via skills:
+# - rbs-syntax: RBS syntax guide
+# - rbs-inline-syntax: RBS Inline syntax guide
+# - steep-reference: Steep type checker documentation
+# - rbs-collection-reference: RBS gem collection setup
+# - rbs-rails-reference: RBS Rails type generation
+# These skills will be auto-activated as needed during the setup process
+
 # Setup configurations
 file = File.copy(File.join(plugin_base_path, 'templates/rbs_goose.template.yml'), './rbs_goose.yml')
 
@@ -17,12 +25,9 @@ end
 config = Config.load('./rbs_goose.yml')
 unless gemfile.contain?('rbs')
   puts('setup rbs...')
-  fetch('https://github.com/soutaro/steep')
   setup_rbs
 
   if config.type_annotation_mode.inline?
-    fetch('https://github.com/soutaro/rbs-inline')
-
     begin
       setup_rbs_inline
     rescue => CompatibilityError(['rbs-inline', 'rubocop-ast'])
@@ -38,20 +43,17 @@ unless gemfile.contain?('rbs')
     end
   end
 
-  fetch('https://github.com/ruby/gem_rbs_collection')
   setup_rbs_collection
 end
 
 unless gemifle.contain?('steep')
   puts('setup steep...')
-  fetch('https://github.com/soutaro/steep')
   setup_steep
   update_steep_config(directory_structure)
 end
 
 if rails_app? && !gemfile.contain?('rbs')
   puts('setup rbs-rails...')
-  fetch('https://github.com/pocke/rbs_rails')
   setup_rails
 end
 

--- a/plugins/rbs-goose/internal/type_file.md
+++ b/plugins/rbs-goose/internal/type_file.md
@@ -1,8 +1,8 @@
 Follow these instructions:
 
 ```
-# Load Documentation
-fetch('https://github.com/ruby/rbs/blob/master/docs/syntax.md')
+# Note: RBS syntax guide is available via the rbs-syntax skill
+# The skill will be auto-activated when working with RBS type definitions
 
 while (typecheck_command.run.type_errors > 0) do
   fix_type_errors

--- a/plugins/rbs-goose/internal/type_inline.md
+++ b/plugins/rbs-goose/internal/type_inline.md
@@ -1,8 +1,8 @@
 Follow these instructions:
 
 ```
-# Load Documentation
-fetch('https://github.com/soutaro/rbs-inline/wiki/Syntax-guide')
+# Note: RBS Inline syntax guide is available via the rbs-inline-syntax skill
+# The skill will be auto-activated when working with RBS Inline annotations
 
 # Type check and fix
 def generate_fig_and_type_check

--- a/plugins/rbs-goose/skills/rbs-collection-reference/SKILL.md
+++ b/plugins/rbs-goose/skills/rbs-collection-reference/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: RBS Gem Collection Reference
+description: Provides documentation for RBS gem collection setup and usage
+version: 1.0.0
+---
+
+# RBS Gem Collection Reference
+
+## When to Use This Skill
+
+This skill should be used when:
+- Setting up RBS type definitions for third-party gems
+- Managing RBS type definition dependencies
+- Troubleshooting missing type definitions for gems
+
+## RBS Collection Overview
+
+Reference: https://github.com/ruby/gem_rbs_collection
+
+The RBS gem collection is a repository of RBS type definitions for popular Ruby gems. It allows you to use type definitions for third-party libraries without writing them yourself.
+
+### Installation
+
+Add to Gemfile (usually already included with `rbs` gem):
+```ruby
+gem 'rbs'
+```
+
+### Configuration
+
+Create `rbs_collection.yaml` in your project root:
+
+```yaml
+# rbs_collection.yaml
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    revision: main
+    repo_dir: gems
+
+path: .gem_rbs_collection
+
+gems:
+  # Add gems you want type definitions for
+  - name: activesupport
+  - name: actionpack
+  - name: activerecord
+  - name: rack
+```
+
+### Common Configuration
+
+#### Rails Application
+```yaml
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    revision: main
+    repo_dir: gems
+
+path: .gem_rbs_collection
+
+gems:
+  - name: activesupport
+  - name: actionpack
+  - name: activerecord
+  - name: activejob
+  - name: actionview
+  - name: actionmailer
+  - name: railties
+  - name: rack
+  - name: concurrent-ruby
+```
+
+#### Common Ruby Gems
+```yaml
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    revision: main
+    repo_dir: gems
+
+path: .gem_rbs_collection
+
+gems:
+  - name: minitest
+  - name: rspec
+  - name: rake
+  - name: thor
+  - name: dry-types
+  - name: dry-struct
+```
+
+### Managing the Collection
+
+#### Install Type Definitions
+```bash
+bundle exec rbs collection install
+```
+
+This downloads RBS type definitions for the gems specified in `rbs_collection.yaml` into the `.gem_rbs_collection/` directory.
+
+#### Update Collection
+```bash
+bundle exec rbs collection update
+```
+
+Updates to the latest type definitions from the collection.
+
+#### Clean Collection
+```bash
+bundle exec rbs collection clean
+```
+
+Removes unused type definition files.
+
+### Directory Structure
+
+After running `rbs collection install`:
+```
+.gem_rbs_collection/
+  activesupport/
+    5.2/
+      activesupport.rbs
+  actionpack/
+    5.2/
+      actionpack.rbs
+```
+
+### Using with Steep
+
+Steep automatically uses RBS collection when configured:
+
+```ruby
+# Steepfile
+target :app do
+  signature "sig"
+  check "lib"
+
+  # Steep will automatically load from .gem_rbs_collection/
+end
+```
+
+### Version Management
+
+RBS collection supports different gem versions:
+
+```yaml
+gems:
+  # Specify version
+  - name: activesupport
+    version: '7.0'
+
+  # Without version, uses latest available
+  - name: rack
+```
+
+### Custom Sources
+
+You can add custom RBS repositories:
+
+```yaml
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    revision: main
+    repo_dir: gems
+
+  # Custom repository
+  - type: git
+    name: mycompany/custom-rbs
+    revision: main
+    repo_dir: gems
+
+gems:
+  - name: activesupport
+  - name: our-custom-gem
+```
+
+### Ignoring Gems
+
+If a gem doesn't have RBS definitions or you want to skip it:
+
+```yaml
+gems:
+  - name: activesupport
+
+  # This gem will be ignored (no type checking)
+  - name: some-untyped-gem
+    ignore: true
+```
+
+### Git Ignore Configuration
+
+Add to `.gitignore`:
+```
+.gem_rbs_collection/
+rbs_collection.lock.yaml
+```
+
+The lock file (`rbs_collection.lock.yaml`) should typically be committed to ensure consistent type definitions across environments.
+
+### Common Issues
+
+#### Gem Not Found in Collection
+If a gem's type definitions aren't available:
+1. Check if the gem is in the collection: https://github.com/ruby/gem_rbs_collection/tree/main/gems
+2. Write custom RBS definitions in `sig/` directory
+3. Consider contributing types to the collection
+
+#### Version Mismatch
+If you get version-related errors:
+```yaml
+gems:
+  - name: activesupport
+    version: '6.1'  # Match your Gemfile version
+```
+
+#### Missing Types After Update
+Re-install the collection:
+```bash
+bundle exec rbs collection clean
+bundle exec rbs collection install
+```
+
+### Writing Custom Definitions
+
+For gems not in the collection, create definitions in `sig/`:
+
+```
+sig/
+  custom_gem.rbs
+```
+
+Example:
+```rbs
+# sig/custom_gem.rbs
+module CustomGem
+  class Client
+    def initialize: (api_key: String) -> void
+    def fetch_data: (String id) -> Hash[Symbol, untyped]
+  end
+end
+```
+
+### CI/CD Integration
+
+Example GitHub Actions:
+```yaml
+- name: Install RBS Collection
+  run: bundle exec rbs collection install
+
+- name: Type Check
+  run: bundle exec steep check
+```
+
+### Best Practices
+
+1. **Commit Lock File**: Commit `rbs_collection.lock.yaml` for consistency
+2. **Gitignore Collection Dir**: Add `.gem_rbs_collection/` to `.gitignore`
+3. **Specify Versions**: When possible, specify gem versions in `rbs_collection.yaml`
+4. **Regular Updates**: Run `rbs collection update` periodically
+5. **Contribute Back**: If you write types for popular gems, contribute to the collection
+
+### Available Gems in Collection
+
+Popular gems with RBS types available:
+- Rails ecosystem: activesupport, actionpack, activerecord, etc.
+- Testing: rspec, minitest
+- Common utilities: concurrent-ruby, thor, rake
+- Database: pg, mysql2, sqlite3
+- Web: rack, sinatra
+
+Check the full list: https://github.com/ruby/gem_rbs_collection/tree/main/gems
+
+## Important Notes
+
+- Always run `rbs collection install` after `bundle install`
+- The collection directory `.gem_rbs_collection/` should be gitignored
+- Lock file ensures consistent types across environments
+- Not all gems have RBS definitions available
+- You can write and contribute missing type definitions
+- Collection integrates seamlessly with Steep and other RBS tools

--- a/plugins/rbs-goose/skills/rbs-inline-syntax/SKILL.md
+++ b/plugins/rbs-goose/skills/rbs-inline-syntax/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: RBS Inline Syntax Guide
+description: Provides comprehensive RBS Inline syntax documentation for writing type annotations as Ruby comments
+version: 1.0.0
+---
+
+# RBS Inline Syntax Guide
+
+## When to Use This Skill
+
+This skill should be used when:
+- Writing inline type annotations in Ruby code using RBS Inline
+- Adding type signatures as comments within Ruby files
+- Converting between inline and separate RBS file formats
+
+## RBS Inline Syntax Documentation
+
+Reference: https://github.com/soutaro/rbs-inline/wiki/Syntax-guide
+
+### Basic Inline Annotations
+
+#### Method Signatures
+
+```ruby
+class User
+  # @rbs name: String
+  # @rbs age: Integer
+  # @rbs return: void
+  def initialize(name, age)
+    @name = name
+    @age = age
+  end
+
+  # @rbs return: String
+  def greet
+    "Hello, #{@name}!"
+  end
+end
+```
+
+#### Attribute Annotations
+
+```ruby
+class Person
+  # @rbs!
+  #   attr_reader name: String
+  #   attr_accessor age: Integer
+  attr_reader :name
+  attr_accessor :age
+end
+```
+
+### Method Type Annotations
+
+#### Simple Types
+```ruby
+# @rbs (String, Integer) -> String
+def format_message(text, count)
+  "#{text}: #{count}"
+end
+```
+
+#### Optional Parameters
+```ruby
+# @rbs (String, ?Integer) -> String
+def greet(name, age = nil)
+  age ? "#{name} (#{age})" : name
+end
+```
+
+#### Keyword Arguments
+```ruby
+# @rbs (name: String, age: Integer) -> void
+def register(name:, age:)
+  # ...
+end
+
+# @rbs (name: String, ?age: Integer) -> void
+def register_with_optional(name:, age: 18)
+  # ...
+end
+```
+
+#### Block Parameters
+```ruby
+# @rbs () { (String) -> void } -> void
+def each_name(&block)
+  names.each(&block)
+end
+```
+
+#### Multiple Overloads
+```ruby
+# @rbs (String) -> String
+#    | (Integer) -> Integer
+def identity(value)
+  value
+end
+```
+
+### Class and Module Annotations
+
+#### Class Definitions
+```ruby
+# @rbs!
+#   class User
+#     attr_reader id: Integer
+#     attr_reader email: String
+#
+#     def initialize: (Integer id, String email) -> void
+#     def active?: () -> bool
+#   end
+class User
+  attr_reader :id, :email
+
+  def initialize(id, email)
+    @id = id
+    @email = email
+  end
+
+  def active?
+    # ...
+  end
+end
+```
+
+#### Module Definitions
+```ruby
+# @rbs!
+#   module Loggable
+#     def log: (String message) -> void
+#   end
+module Loggable
+  def log(message)
+    puts message
+  end
+end
+```
+
+### Instance Variable Annotations
+
+```ruby
+class Container
+  # @rbs @items: Array[String]
+  def initialize
+    @items = []
+  end
+
+  # @rbs return: Array[String]
+  def items
+    @items
+  end
+end
+```
+
+### Generic Types
+
+#### Generic Classes
+```ruby
+# @rbs!
+#   class Box[T]
+#     @value: T
+#
+#     def initialize: (T) -> void
+#     def value: () -> T
+#   end
+class Box
+  def initialize(value)
+    @value = value
+  end
+
+  def value
+    @value
+  end
+end
+```
+
+#### Generic Methods
+```ruby
+# @rbs [T] (T) -> T
+def identity(value)
+  value
+end
+```
+
+### Type Declarations
+
+#### Union Types
+```ruby
+# @rbs (String | Integer) -> String
+def to_string(value)
+  value.to_s
+end
+```
+
+#### Optional Types
+```ruby
+# @rbs return: String?
+def find_name(id)
+  # May return nil
+end
+```
+
+#### Array and Hash Types
+```ruby
+# @rbs return: Array[String]
+def names
+  ["Alice", "Bob"]
+end
+
+# @rbs return: Hash[Symbol, Integer]
+def counts
+  { apples: 5, oranges: 3 }
+end
+```
+
+### Special Annotations
+
+#### Skip Type Checking
+```ruby
+# @rbs skip
+def untyped_method
+  # This method won't be type-checked
+end
+```
+
+#### Inherits Signature
+```ruby
+class Parent
+  # @rbs (String) -> String
+  def process(text)
+    text.upcase
+  end
+end
+
+class Child < Parent
+  # @rbs inherits
+  def process(text)
+    super.downcase
+  end
+end
+```
+
+## Conversion Between Formats
+
+### Inline to Separate Files
+Use the `rbs-inline` command to generate separate RBS files:
+```bash
+bundle exec rbs-inline --output sig/ lib/
+```
+
+### Block Comment Style
+
+For complex type definitions, use block comments:
+```ruby
+# @rbs!
+#   type user_id = Integer
+#   type user_name = String
+#
+#   class UserService
+#     def find_user: (user_id) -> User?
+#     def create_user: (user_name) -> User
+#   end
+```
+
+## Best Practices
+
+1. **Consistent Style**: Use either `@rbs` or `@rbs!` consistently within a file
+2. **Inline for Simple Cases**: Use inline annotations for straightforward method signatures
+3. **Block Comments for Complex Types**: Use `@rbs!` blocks for class-level definitions
+4. **Document Return Types**: Always specify return types, even for `void`
+5. **Annotate Instance Variables**: Document instance variable types for clarity
+6. **Use Type Inference**: Let RBS Inline infer types when obvious
+
+## Common Patterns
+
+### ActiveRecord Models
+```ruby
+# @rbs!
+#   class User < ApplicationRecord
+#     attr_accessor email: String
+#     attr_accessor name: String?
+#
+#     def self.find_by_email: (String) -> User?
+#     def full_name: () -> String
+#   end
+class User < ApplicationRecord
+  # ...
+end
+```
+
+### Service Objects
+```ruby
+class UserRegistrationService
+  # @rbs email: String
+  # @rbs password: String
+  # @rbs return: void
+  def initialize(email:, password:)
+    @email = email
+    @password = password
+  end
+
+  # @rbs return: User
+  #    | return: { errors: Array[String] }
+  def call
+    # ...
+  end
+end
+```
+
+## Important Notes
+
+- RBS Inline generates `.rbs` files from inline annotations
+- Use `rbs-inline --output sig/ lib/` to generate type definition files
+- Generated files should be gitignored and regenerated during CI/build
+- The inline syntax is converted to standard RBS syntax in generated files
+- Use `steep check` after generating RBS files to validate types

--- a/plugins/rbs-goose/skills/rbs-rails-reference/SKILL.md
+++ b/plugins/rbs-goose/skills/rbs-rails-reference/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: RBS Rails Reference
+description: Provides documentation for RBS Rails type generation in Rails applications
+version: 1.0.0
+---
+
+# RBS Rails Reference
+
+## When to Use This Skill
+
+This skill should be used when:
+- Setting up type checking for Rails applications
+- Generating RBS definitions for ActiveRecord models
+- Working with Rails-specific type definitions
+- Troubleshooting Rails type generation issues
+
+## RBS Rails Overview
+
+Reference: https://github.com/pocke/rbs_rails
+
+RBS Rails is a tool that automatically generates RBS type definitions for Rails applications, particularly for ActiveRecord models, routes, and other Rails-specific code.
+
+### Installation
+
+Add to Gemfile:
+```ruby
+group :development do
+  gem 'rbs_rails', require: false
+end
+```
+
+Then run:
+```bash
+bundle install
+```
+
+### Basic Usage
+
+#### Generate RBS Files
+```bash
+bundle exec rbs_rails generate
+```
+
+This generates RBS type definitions in `sig/generated/` directory.
+
+#### Generate for Specific Models
+```bash
+bundle exec rbs_rails generate --model=User
+bundle exec rbs_rails generate --model=Post,Comment
+```
+
+### Generated Files Structure
+
+```
+sig/
+  generated/
+    active_record/
+      model.rbs
+    app/
+      models/
+        user.rbs
+        post.rbs
+    config/
+      routes.rbs
+```
+
+### What Gets Generated
+
+#### ActiveRecord Models
+
+For a model like:
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  belongs_to :team
+  has_many :posts
+
+  validates :email, presence: true
+
+  scope :active, -> { where(active: true) }
+end
+```
+
+RBS Rails generates:
+```rbs
+# sig/generated/app/models/user.rbs
+class User < ApplicationRecord
+  extend _ActiveRecord_Relation_ClassMethods[User, User::ActiveRecord_Relation]
+
+  attr_accessor email: String
+  attr_accessor team_id: Integer
+  attr_accessor active: bool
+  attr_accessor created_at: Time
+  attr_accessor updated_at: Time
+
+  def team: () -> Team
+  def team=: (Team) -> Team
+
+  def posts: () -> ActiveRecord::Associations::CollectionProxy[Post]
+  def posts=: (Array[Post]) -> Array[Post]
+
+  def self.active: () -> User::ActiveRecord_Relation
+end
+```
+
+#### Routes
+
+For routes defined in `config/routes.rb`:
+```ruby
+Rails.application.routes.draw do
+  resources :users
+  get 'dashboard', to: 'dashboard#index'
+end
+```
+
+Generates route helpers:
+```rbs
+# sig/generated/config/routes.rbs
+module ActionDispatch
+  module Routing
+    class RouteSet
+      def users_path: (?untyped options) -> String
+      def user_path: (untyped id, ?untyped options) -> String
+      def dashboard_path: (?untyped options) -> String
+    end
+  end
+end
+```
+
+### Configuration
+
+Create `lib/tasks/rbs.rake`:
+```ruby
+# lib/tasks/rbs.rake
+namespace :rbs do
+  desc 'Generate RBS files for Rails application'
+  task generate: :environment do
+    require 'rbs_rails'
+    RbsRails.generate(
+      signature_root_dir: Pathname('sig/generated')
+    )
+  end
+end
+```
+
+Then use:
+```bash
+bundle exec rake rbs:generate
+```
+
+### Integration with Steep
+
+Update `Steepfile`:
+```ruby
+target :app do
+  signature "sig"
+  signature "sig/generated"  # Include generated Rails types
+
+  check "app"
+  check "lib"
+
+  library "pathname"
+  library "logger"
+  library "monitor"
+  library "date"
+  library "mutex_m"
+  library "uri"
+  library "time"
+  library "singleton"
+end
+```
+
+### Git Configuration
+
+Add to `.gitignore`:
+```
+sig/generated/
+```
+
+Generated files should be recreated during development and CI, not committed.
+
+### CI/CD Integration
+
+Example GitHub Actions:
+```yaml
+- name: Setup Database
+  run: |
+    bundle exec rails db:create
+    bundle exec rails db:schema:load
+
+- name: Generate Rails RBS
+  run: bundle exec rbs_rails generate
+
+- name: Install RBS Collection
+  run: bundle exec rbs collection install
+
+- name: Type Check
+  run: bundle exec steep check
+```
+
+### Common Patterns
+
+#### Custom Model Methods
+
+For custom methods in models:
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  def full_name
+    "#{first_name} #{last_name}"
+  end
+end
+```
+
+Add manual RBS in `sig/app/models/user.rbs` (not in `generated/`):
+```rbs
+# sig/app/models/user.rbs
+class User
+  def full_name: () -> String
+end
+```
+
+#### Service Objects
+
+Create manual definitions for service objects:
+```rbs
+# sig/app/services/user_registration_service.rbs
+class UserRegistrationService
+  attr_reader user: User
+
+  def initialize: (email: String, password: String) -> void
+  def call: () -> bool
+  def errors: () -> Array[String]
+end
+```
+
+### Advanced Configuration
+
+#### Customize Output Directory
+```ruby
+RbsRails.generate(
+  signature_root_dir: Pathname('sig/rbs_rails')
+)
+```
+
+#### Skip Specific Models
+```ruby
+RbsRails.generate(
+  skip_models: ['InternalModel', 'LegacyTable']
+)
+```
+
+### Working with Associations
+
+RBS Rails handles associations well:
+
+```ruby
+# app/models/post.rb
+class Post < ApplicationRecord
+  belongs_to :user
+  belongs_to :category, optional: true
+  has_many :comments
+  has_many :tags, through: :post_tags
+  has_one :featured_image, class_name: 'Image'
+end
+```
+
+Generates:
+```rbs
+class Post < ApplicationRecord
+  def user: () -> User
+  def user=: (User) -> User
+
+  def category: () -> Category?
+  def category=: (Category?) -> Category?
+
+  def comments: () -> ActiveRecord::Associations::CollectionProxy[Comment]
+  def tags: () -> ActiveRecord::Associations::CollectionProxy[Tag]
+
+  def featured_image: () -> Image?
+  def build_featured_image: (?untyped attributes) -> Image
+  def create_featured_image: (?untyped attributes) -> Image
+end
+```
+
+### Enum Support
+
+For ActiveRecord enums:
+```ruby
+class User < ApplicationRecord
+  enum role: { user: 0, admin: 1, moderator: 2 }
+end
+```
+
+Generates:
+```rbs
+class User < ApplicationRecord
+  attr_accessor role: String
+
+  def user?: () -> bool
+  def admin?: () -> bool
+  def moderator?: () -> bool
+
+  def user!: () -> bool
+  def admin!: () -> bool
+  def moderator!: () -> bool
+end
+```
+
+### Validation and Callbacks
+
+RBS Rails doesn't generate types for validations and callbacks, but you can add them manually:
+
+```rbs
+# sig/app/models/user.rbs
+class User
+  # Callbacks
+  def send_welcome_email: () -> void
+
+  # Custom validations
+  def email_format_valid?: () -> bool
+end
+```
+
+### Troubleshooting
+
+#### Database Not Set Up
+RBS Rails needs database access to read schema:
+```bash
+bundle exec rails db:create
+bundle exec rails db:schema:load
+```
+
+#### Outdated Generated Files
+Regenerate after schema changes:
+```bash
+bundle exec rbs_rails generate
+```
+
+#### Missing Association Types
+Ensure all models are loaded:
+```bash
+RAILS_ENV=development bundle exec rbs_rails generate
+```
+
+### Best Practices
+
+1. **Regenerate Regularly**: Run after migrations and model changes
+2. **Don't Edit Generated Files**: They're overwritten on regeneration
+3. **Use Separate Dir**: Keep manual RBS separate from generated
+4. **Gitignore Generated**: Don't commit `sig/generated/`
+5. **CI Generation**: Generate in CI to ensure consistency
+6. **Manual Additions**: Add custom methods in `sig/` (not `sig/generated/`)
+
+### Directory Organization
+
+Recommended structure:
+```
+sig/
+  app/
+    models/
+      user.rbs          # Manual additions
+      post.rbs          # Manual additions
+    services/
+      user_service.rbs  # Manual service objects
+  generated/            # Generated by rbs_rails (gitignored)
+    app/
+      models/
+        user.rbs
+        post.rbs
+```
+
+## Important Notes
+
+- RBS Rails requires database access to read schema
+- Generated files should be regenerated, not manually edited
+- Always gitignore `sig/generated/` directory
+- Keep manual RBS definitions separate from generated ones
+- Run generation in CI to keep types up-to-date
+- Works seamlessly with Steep and other RBS tools
+- Supports Rails 6.0+

--- a/plugins/rbs-goose/skills/rbs-syntax/SKILL.md
+++ b/plugins/rbs-goose/skills/rbs-syntax/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: RBS Syntax Guide
+description: Provides comprehensive RBS syntax documentation for writing type signatures in separate .rbs files
+version: 1.0.0
+---
+
+# RBS Syntax Guide
+
+## When to Use This Skill
+
+This skill should be used when:
+- Writing RBS type signatures in separate `.rbs` files
+- Defining class and module type signatures
+- Creating method type definitions
+- Working with RBS generics and type parameters
+
+## RBS Syntax Documentation
+
+Reference: https://github.com/ruby/rbs/blob/master/docs/syntax.md
+
+### Basic Type Signatures
+
+#### Class Definitions
+```rbs
+class MyClass
+  attr_reader name: String
+  attr_accessor age: Integer
+
+  def initialize: (String name, Integer age) -> void
+  def greet: () -> String
+end
+```
+
+#### Module Definitions
+```rbs
+module MyModule
+  def module_method: () -> String
+end
+```
+
+### Method Signatures
+
+#### Simple Methods
+```rbs
+def method_name: (ArgType1, ArgType2) -> ReturnType
+```
+
+#### Optional Parameters
+```rbs
+def method_name: (String, ?Integer) -> String
+```
+
+#### Keyword Arguments
+```rbs
+def method_name: (name: String, age: Integer) -> void
+def with_optional: (name: String, ?age: Integer) -> void
+```
+
+#### Block Parameters
+```rbs
+def method_name: () { (String) -> void } -> void
+```
+
+#### Multiple Overloads
+```rbs
+def method_name: (String) -> String
+               | (Integer) -> Integer
+```
+
+### Type Definitions
+
+#### Built-in Types
+- `Integer`, `String`, `Symbol`, `TrueClass`, `FalseClass`, `NilClass`
+- `Array[T]`, `Hash[K, V]`, `Range[T]`
+- `bool` (alias for `TrueClass | FalseClass`)
+- `void` (for methods that don't return meaningful values)
+- `untyped` (for dynamically typed values)
+
+#### Union Types
+```rbs
+String | Integer
+String | nil
+```
+
+#### Optional Types (Shorthand for T | nil)
+```rbs
+String?
+```
+
+#### Tuple Types
+```rbs
+[String, Integer]
+[String, Integer, bool]
+```
+
+#### Record Types
+```rbs
+{ name: String, age: Integer }
+```
+
+### Generics
+
+#### Generic Classes
+```rbs
+class Box[T]
+  attr_reader value: T
+
+  def initialize: (T) -> void
+end
+```
+
+#### Generic Methods
+```rbs
+def identity: [T] (T) -> T
+```
+
+#### Type Bounds
+```rbs
+class Container[T < Comparable]
+  def max: () -> T
+end
+```
+
+### Interface Types
+
+```rbs
+interface _Each[T]
+  def each: () { (T) -> void } -> void
+end
+```
+
+### Type Aliases
+
+```rbs
+type user_id = Integer
+type user_name = String
+type user = { id: user_id, name: user_name }
+```
+
+### Constants
+
+```rbs
+CONSTANT_NAME: String
+```
+
+### Inheritance and Mixins
+
+```rbs
+class Child < Parent
+  include MyModule
+  extend AnotherModule
+end
+```
+
+## Best Practices
+
+1. **Start Simple**: Begin with basic type signatures and refine them as needed
+2. **Use Union Types**: Prefer `String | Integer` over `untyped` when possible
+3. **Document Overloads**: Use method overloads to express different calling patterns
+4. **Leverage Generics**: Use generics for container classes and reusable components
+5. **Type Aliases**: Define type aliases for complex or frequently used types
+
+## Common Patterns
+
+### ActiveRecord Models
+```rbs
+class User < ApplicationRecord
+  attr_accessor email: String
+  attr_accessor name: String?
+
+  def self.find_by_email: (String) -> User?
+  def full_name: () -> String
+end
+```
+
+### Service Objects
+```rbs
+class UserRegistrationService
+  def initialize: (email: String, password: String) -> void
+  def call: () -> User
+              | () -> { errors: Array[String] }
+end
+```
+
+## Important Notes
+
+- RBS files should be placed in the `sig/` directory by convention
+- Use `steep check` to validate your type signatures
+- Generated RBS files (from tools like rbs_rails) should be in `sig/generated/`
+- Keep manually written signatures in `sig/` (not in `generated/`)

--- a/plugins/rbs-goose/skills/steep-reference/SKILL.md
+++ b/plugins/rbs-goose/skills/steep-reference/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: Steep Type Checker Reference
+description: Provides Steep type checker documentation and configuration guidance
+version: 1.0.0
+---
+
+# Steep Type Checker Reference
+
+## When to Use This Skill
+
+This skill should be used when:
+- Configuring Steep for type checking
+- Understanding Steep error messages
+- Setting up Steep in a Ruby project
+- Troubleshooting type checking issues
+
+## Steep Overview
+
+Reference: https://github.com/soutaro/steep
+
+Steep is a static type checker for Ruby that uses RBS type definitions. It analyzes Ruby code against RBS signatures to find type errors.
+
+### Installation
+
+Add to Gemfile:
+```ruby
+gem 'steep'
+```
+
+Then run:
+```bash
+bundle install
+```
+
+### Configuration
+
+Steep uses a `Steepfile` for configuration:
+
+```ruby
+# Steepfile
+target :app do
+  signature "sig"
+
+  check "lib"
+  check "app"
+
+  # Ignore specific files or patterns
+  # ignore "lib/generated/**/*.rb"
+
+  # Configure libraries
+  library "pathname"
+  library "logger"
+  library "monitor"
+  library "date"
+  library "mutex_m"
+  library "uri"
+  library "time"
+  library "singleton"
+end
+```
+
+### Common Configuration Patterns
+
+#### Rails Application
+```ruby
+target :app do
+  signature "sig"
+
+  check "app"
+  check "lib"
+
+  ignore "vendor/**/*"
+
+  # Rails libraries
+  library "pathname"
+  library "logger"
+  library "monitor"
+  library "date"
+  library "mutex_m"
+  library "uri"
+  library "time"
+  library "singleton"
+end
+```
+
+#### Multiple Targets
+```ruby
+target :lib do
+  signature "sig"
+  check "lib"
+
+  library "pathname"
+end
+
+target :spec do
+  signature "sig"
+  check "spec"
+
+  library "pathname"
+  library "rspec"
+end
+```
+
+### Running Steep
+
+#### Type Check
+```bash
+bundle exec steep check
+```
+
+#### Verbose Output
+```bash
+bundle exec steep check --verbose
+```
+
+#### Watch Mode (Auto-recheck on file changes)
+```bash
+bundle exec steep watch
+```
+
+#### Statistics
+```bash
+bundle exec steep stats
+```
+
+### Common Error Messages
+
+#### Type Mismatch
+```
+Type mismatch:
+  expected: String
+  actual:   Integer
+```
+
+**Solution**: Check the method signature and ensure the correct type is being passed or returned.
+
+#### Method Not Found
+```
+Cannot find method `unknown_method` on `ClassName`
+```
+
+**Solution**: Add the method signature to the RBS file or check for typos.
+
+#### Undefined Constant
+```
+Cannot find constant `CONSTANT_NAME`
+```
+
+**Solution**: Define the constant in the RBS signature file.
+
+#### NoMethodError for nil
+```
+Type `String?` may be nil, but the method `upcase` is called
+```
+
+**Solution**: Add nil check or use safe navigation operator `&.`
+
+### Type Checking Best Practices
+
+1. **Start with Core Classes**: Type check main business logic first
+2. **Ignore Generated Code**: Use `ignore` directive for generated files
+3. **Use RBS Collection**: Leverage existing type definitions from gem_rbs_collection
+4. **Incremental Adoption**: Start with one directory and expand gradually
+5. **Fix Errors Iteratively**: Address errors one at a time
+
+### Working with RBS Collection
+
+Steep integrates with RBS gem collection for third-party library types:
+
+```yaml
+# rbs_collection.yaml
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    revision: main
+    repo_dir: gems
+
+path: .gem_rbs_collection
+
+gems:
+  - name: activesupport
+  - name: actionpack
+  - name: activerecord
+```
+
+Install collection:
+```bash
+bundle exec rbs collection install
+```
+
+### Integration with RBS Inline
+
+When using RBS Inline, generate RBS files before running Steep:
+
+```bash
+# Generate RBS from inline annotations
+bundle exec rbs-inline --output sig/ lib/
+
+# Then run Steep
+bundle exec steep check
+```
+
+### CI/CD Integration
+
+Example GitHub Actions workflow:
+```yaml
+- name: Type check with Steep
+  run: |
+    bundle exec rbs collection install
+    bundle exec rbs-inline --output sig/ lib/  # if using RBS Inline
+    bundle exec steep check
+```
+
+## Common Steep Commands
+
+### Check Specific Files
+```bash
+bundle exec steep check lib/specific_file.rb
+```
+
+### Show Type Information
+```bash
+bundle exec steep stats --format=table
+```
+
+### Validate Steepfile
+```bash
+bundle exec steep validate
+```
+
+## Troubleshooting
+
+### Steep is Too Strict
+- Use `untyped` for dynamic code sections
+- Add `# @type var variable: untyped` comments
+- Consider using `ignore` for problematic files
+
+### Performance Issues
+- Use `ignore` for large generated files
+- Break down large RBS files into smaller modules
+- Run Steep on specific directories instead of entire codebase
+
+### Library Types Missing
+- Check if types exist in gem_rbs_collection
+- Add custom RBS definitions in `sig/` directory
+- Contribute types back to gem_rbs_collection
+
+## Important Notes
+
+- Steep requires RBS type definitions to work
+- Always run `rbs collection install` after updating dependencies
+- Steep works best with incremental adoption
+- Use `steep watch` during development for immediate feedback
+- Type errors don't prevent Ruby code from running (static analysis only)


### PR DESCRIPTION
Resolves #13

This PR extracts RBS documentation from fetch() calls into reusable skills, solving two key problems:

1. Eliminates redundant fetching of the same documentation on every run
2. Removes dependency on plugin installation directory paths

### Changes

- Created 5 comprehensive skills for RBS ecosystem documentation:
  - rbs-syntax: RBS syntax guide for separate .rbs files
  - rbs-inline-syntax: RBS Inline syntax for inline annotations
  - steep-reference: Steep type checker documentation
  - rbs-collection-reference: RBS gem collection setup
  - rbs-rails-reference: RBS Rails type generation

- Updated command files to remove fetch() calls:
  - setup.md: Removed fetch calls for steep, rbs-inline, gem_rbs_collection, rbs_rails
  - internal/type_inline.md: Removed RBS Inline syntax fetch
  - internal/type_file.md: Removed RBS syntax fetch

Skills are now auto-activated when needed, providing documentation without repeated fetching or path dependencies.

Generated with [Claude Code](https://claude.ai/code)