### PR TITLE
dev-guidelines: スキルに詳細なルールを追加してCLAUDE.mdを軽量化

### DIFF
--- a/plugins/dev-guidelines/skills/implementation-workflow/SKILL.md
+++ b/plugins/dev-guidelines/skills/implementation-workflow/SKILL.md
@@ -6,6 +6,20 @@ version: 1.0.0
 
 # Code Implementation Workflow
 
+## CRITICAL RULE: Never Push Directly to Default Branches
+
+**ABSOLUTELY PROHIBITED:**
+- ❌ `git push origin main`
+- ❌ `git push origin develop`
+- ❌ `git push origin master`
+
+**ALL changes must go through Pull Requests. NO EXCEPTIONS.**
+
+If you need to add files to default branch:
+1. Create a separate PR branch
+2. Submit a proper Pull Request
+3. Never bypass the PR process
+
 ## Core Rule: Branch Hygiene First
 
 **Before ANY code implementation**, follow proper branch workflow:

--- a/plugins/dev-guidelines/skills/pr-description-format/SKILL.md
+++ b/plugins/dev-guidelines/skills/pr-description-format/SKILL.md
@@ -48,3 +48,26 @@ Specific implementation details
 - Write for code reviewers to understand changes quickly
 - Focus on clarity and completeness
 - Include relevant context and rationale
+
+## PR Workflow Requirements
+
+### 1. Always Start with Draft PR
+```bash
+gh pr create --draft
+```
+Only switch to open state when explicitly instructed to request review:
+```bash
+gh pr ready
+```
+
+### 2. Clarify "Why" Before Creating PR
+If the reason for changes is not clear or not provided by the user:
+- **ALWAYS ask the user for clarification** before creating the PR
+- Include business context, problem being solved, or improvement being made
+- Ensure reviewers can understand both implementation and motivation
+
+### 3. Update PR Description on New Commits
+When pushing new commits to an existing PR:
+- Always update the PR description to reflect current state: `gh pr edit --body`
+- Ensure description accurately represents ALL changes, not just initial implementation
+- Base the update on latest commit history and changes

--- a/plugins/dev-guidelines/skills/web-tools/SKILL.md
+++ b/plugins/dev-guidelines/skills/web-tools/SKILL.md
@@ -37,3 +37,21 @@ For knowledge management and documentation:
 - Leverage pre-configured Obsidian tools when available
 - Consider data privacy and website terms of service
 - Document your research process for reproducibility
+
+## Required Tool Usage Rules
+
+### GitHub Information Retrieval
+**Always use gh command when retrieving information from GitHub:**
+- Pull Request information: `gh pr view`, `gh pr list`
+- Issue information: `gh issue view`, `gh issue list`
+- Repository information: `gh repo view`
+- GitHub Actions information: `gh run list`, `gh run view`
+- **Prohibited:** Do not use WebFetch or WebSearch for GitHub information
+
+### Application Behavior Verification
+**Always use Playwright for web application behavior verification:**
+- UI interaction testing: Use `mcp__playwright__browser_*` tool suite
+- Screen screenshots: `mcp__playwright__browser_take_screenshot`
+- Element operations: `mcp__playwright__browser_click`, `mcp__playwright__browser_type`
+- Page navigation verification: `mcp__playwright__browser_navigate`
+- **Prohibited:** Do not use curl or WebFetch for application behavior verification


### PR DESCRIPTION
## 概要

dev-guidelinesプラグインの各スキルに、ユーザーのCLAUDE.mdに記載されていた詳細なルールを追加しました。これにより、ユーザー側のCLAUDE.mdを軽量化し、詳細な方法論をスキル側で管理できるようになります。

## 変更の背景

ユーザーのCLAUDE.mdが詳細なワークフロー記述で肥大化しており、「常に必要な記述」と「特定の作業で有効な記述」が混在していました。スキルに移行済みの内容については、CLAUDE.mdには利用タイミングの記述だけを残し、詳細はスキル側で管理する方が適切であると判断しました。

## 変更詳細

### implementation-workflow/SKILL.md
- **CRITICAL RULE**セクションを追加
  - デフォルトブランチへの直接プッシュ禁止を明示
  - `git push origin main/develop/master`の絶対禁止
  - PR経由での変更を必須化

### pr-description-format/SKILL.md
- **PR Workflow Requirements**セクションを追加
  - ドラフトPRから始める原則（`gh pr create --draft`）
  - 変更理由（Why）が不明な場合はユーザーに質問する義務
  - 新しいコミットをpushした際のPR description更新ルール

### web-tools/SKILL.md
- **Required Tool Usage Rules**セクションを追加
  - GitHub情報取得は`gh`コマンド必須（WebFetch/WebSearch禁止）
  - アプリケーション動作確認はPlaywright必須（curl/WebFetch禁止）
  - 各操作での具体的なツール指定

これらの追加により、スキルがより自己完結的になり、ユーザーのCLAUDE.mdをシンプルに保つことができます。