### PR TITLE
refactor: dev-guidelinesスキルのdescriptionと内容を簡素化

### DIFF
--- a/plugins/dev-guidelines/skills/debugging-process/SKILL.md
+++ b/plugins/dev-guidelines/skills/debugging-process/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Debugging Process
-description: Use this skill when investigating code, analyzing bugs, debugging issues, tracing errors, performing root cause analysis, or understanding unexpected behavior. Report findings in real-time with file:line references and investigate WHY before applying fixes.
+description: Provides systematic debugging methodology for thorough root cause analysis with evidence-based investigation. Use this skill when investigating code, analyzing bugs, tracing errors, or understanding unexpected behavior.
 version: 1.0.0
 ---
 
@@ -8,70 +8,39 @@ version: 1.0.0
 
 ## Core Principles
 
-### 1. Real-Time Investigation Reporting
-
-**Communicate as you investigate**:
-- Share findings immediately with `file_path:line_number` references
-- Explain your reasoning and thought process
-- Let the user verify your understanding
-- Report "I'm checking [X] at [location]" → "Found [Y], suggests [Z]"
-
-### 2. Root Cause Before Fixes
-
-**Never apply quick fixes without understanding**:
-- Ask "Why?" repeatedly (5 Whys technique) to find root causes
-- Distinguish between where errors manifest vs. where they originate
-- Fix the source, not symptoms
-- Understand the mechanism before implementing countermeasures
+1. **Real-Time Reporting**: Share findings immediately with `file:line` references. Report "Checking [X] at [location]" → "Found [Y], suggests [Z]"
+2. **Root Cause First**: Use 5 Whys technique. Fix the source, not symptoms.
 
 ## Investigation Pattern
 
-```markdown
-1. Starting point: "Investigating [X] by checking [Y]"
-2. Evidence: "Found [this] at [location:line]. Suggests [interpretation]"
-3. Following leads: "Based on this, checking [next location]"
-4. Root cause: "After tracing back: [root cause explanation]"
-5. Solution: "Fixing [root cause] by [approach]"
+```
+1. "Investigating [X] by checking [Y]"
+2. "Found [this] at [location:line]. Suggests [interpretation]"
+3. "Based on this, checking [next location]"
+4. Root cause identified → Apply fix
 ```
 
 ## 5 Whys Example
 
 ```
-Problem: Application crashes on submit button click
-
-Why? → Exception in validation function
-Why? → Validation receives null value
+Problem: App crashes on submit
+Why? → Exception in validation
+Why? → Receives null value
 Why? → Form data not initialized
 Why? → Component mounts before API response
-Why? → Race condition in async initialization
-
-Root Cause: Race condition → Fix async initialization order
+Why? → Race condition
+→ Fix: Correct initialization order
 ```
 
-## Anti-Patterns to Avoid
+## Anti-Patterns
 
-❌ **Symptom-based fixes**: Adding try-catch without understanding why it throws
-❌ **Null-checks everywhere**: Instead of understanding why values are null
-❌ **Guessing solutions**: Adding setTimeout hoping it helps
-❌ **Hidden investigation**: Presenting only conclusions without evidence
+- Adding try-catch without understanding why it throws
+- Null-checks everywhere instead of understanding cause
+- Guessing solutions (e.g., setTimeout hoping it helps)
+- Presenting only conclusions without evidence
 
-## Best Practices
+## DO / DON'T
 
-### DO:
-- Use `file:line` format for all code references
-- Share evidence progressively as you discover it
-- Trace errors back to their origin
-- Test your understanding by explaining the causal chain
-- Document why the fix addresses the root cause
+**DO**: Use `file:line` references, share evidence progressively, trace to origin, explain causal chain
 
-### DON'T:
-- Rush to implement fixes
-- Hide your investigation process
-- Fix symptoms without understanding causes
-- Make assumptions without verification
-- Skip explaining the "why"
-
-## Integration with Other Skills
-
-- Works with **implementation-workflow** when fixing bugs (checkout branch, then investigate)
-- Complements **test-driven-approach** (understand bug → write failing test → fix → verify)
+**DON'T**: Rush to fix, hide investigation process, fix symptoms not causes

--- a/plugins/dev-guidelines/skills/design-alternatives/SKILL.md
+++ b/plugins/dev-guidelines/skills/design-alternatives/SKILL.md
@@ -1,83 +1,40 @@
 ---
 name: Design Alternatives
-description: Use this skill when choosing architectures, selecting technologies, evaluating implementation approaches, or making design decisions. Propose 2-3 alternatives with advantages/disadvantages/reasoning/future scenarios for each.
+description: Guides structured evaluation of design options with trade-off analysis. Use this skill when choosing architectures, selecting technologies, evaluating implementation approaches, or making design decisions.
 version: 1.0.0
 ---
 
 # Design and Architecture Decision Process
 
-## Core Principle: Multiple Alternatives with Trade-offs
+## Core Principle
 
-When facing design decisions, **always propose at least 2-3 alternatives** and analyze each comprehensively.
+**Always propose 2-3 alternatives** with comprehensive analysis for each.
 
-## For Each Alternative, Clearly State
+## For Each Alternative
 
-### 1. Advantages
-What are the benefits? What problems does it solve well?
+1. **Advantages**: Benefits and problems it solves well
+2. **Disadvantages**: Drawbacks, limitations, complexities
+3. **Reasoning**: Why this is a good or poor choice
+4. **Future Scenarios**: When it breaks down, scalability concerns
 
-### 2. Disadvantages
-What are the drawbacks, limitations, or complexities?
-
-### 3. Reasoning
-Why would this be a good or poor choice? What factors support or oppose it?
-
-### 4. Future Scenarios
-- When might this design break down?
-- What future requirements might challenge this approach?
-- How does this scale or adapt to changes?
-
-## Example Structure
+## Template
 
 ```markdown
 ## Option 1: [Approach Name]
+**Advantages:** [Benefits]
+**Disadvantages:** [Drawbacks]
+**Reasoning:** [Why this makes sense]
+**Future Scenarios:** Breaks down when [scenario]
 
-**Advantages:**
-- [Benefit 1]
-- [Benefit 2]
-
-**Disadvantages:**
-- [Drawback 1]
-- [Drawback 2]
-
-**Reasoning:**
-[Why this makes sense or doesn't]
-
-**Future Scenarios:**
-- Breaks down when [scenario]
-- Needs changes if [future requirement]
-
-## Option 2: [Alternative Approach]
-[Same structure]
-
-## Option 3: [Another Alternative]
+## Option 2: [Alternative]
 [Same structure]
 
 ## Recommendation
-[Based on current requirements and future considerations]
+[Based on requirements and future considerations]
 ```
 
-## Benefits of This Approach
+## DO / DON'T
 
-- Expands thinking beyond first obvious solution
-- Identifies potential issues early
-- Enables informed decision-making
-- Documents reasoning for future reference
-- Helps stakeholders understand trade-offs
+**DO**: Think broadly, consider long-term implications, make trade-offs explicit, document reasoning
 
-## Best Practices
-
-### DO:
-- Think broadly before settling on a solution
-- Consider long-term implications, not just immediate needs
-- Make implicit costs and trade-offs explicit
-- Document the decision-making process
-
-### DON'T:
-- Rush to the first solution
-- Present only one option as "the best"
-- Ignore future scalability or maintainability
-- Make decisions without exploring alternatives
-
-## Important Note
-
-There is rarely a single "perfect" solution. Different contexts favor different approaches, and future requirements can change the optimal choice.
+**DON'T**: Rush to first solution, present only one option, ignore future scalability

--- a/plugins/dev-guidelines/skills/implementation-workflow/SKILL.md
+++ b/plugins/dev-guidelines/skills/implementation-workflow/SKILL.md
@@ -1,109 +1,47 @@
 ---
 name: Implementation Workflow
-description: Use this skill when implementing code changes, new features, or bug fixes. Ensures proper Git branch management (update main → create feature branch OR checkout PR branch → make changes).
+description: Ensures proper Git branch management and PR workflow for code changes. Use this skill when implementing new features, bug fixes, or any code modifications in a Git repository.
 version: 1.0.0
 ---
 
 # Code Implementation Workflow
 
-## CRITICAL RULE: Never Push Directly to Default Branches
+## CRITICAL: Never Push to Default Branches
 
-**ABSOLUTELY PROHIBITED:**
-- ❌ `git push origin main`
-- ❌ `git push origin develop`
-- ❌ `git push origin master`
+❌ **PROHIBITED**: `git push origin main/develop/master`
 
-**ALL changes must go through Pull Requests. NO EXCEPTIONS.**
+ALL changes must go through Pull Requests. No exceptions.
 
-If you need to add files to default branch:
-1. Create a separate PR branch
-2. Submit a proper Pull Request
-3. Never bypass the PR process
-
-## Core Rule: Branch Hygiene First
-
-**Before ANY code implementation**, follow proper branch workflow:
-
-### For New Work
-```bash
-# Update default branch
-git checkout main && git pull origin main
-
-# Create feature branch with descriptive name
-git checkout -b feature/descriptive-name
-# or: fix/, refactor/, docs/, test/
-```
-
-**Exception**: Only skip branch creation if user explicitly says "work on current branch"
-
-### For Existing PR Work
-```bash
-# Checkout PR branch
-gh pr checkout <PR-number>
-
-# Update branch
-git pull origin <branch-name>
-
-# Make changes, then push to same branch
-git push origin <branch-name>
-```
-
-**Exception**: Only skip checkout if already on PR branch or user says "create new PR instead"
-
-## Decision Tree
+## Workflow Decision
 
 ```
 Start Implementation
     ↓
-Is this for an existing PR?
-    ├─ YES → Checkout PR branch → Update → Implement → Push to same branch
-    └─ NO → User explicitly wants current branch?
-              ├─ YES → Work on current branch
-              └─ NO → Update main → Create feature branch → Implement
+Existing PR? → YES → gh pr checkout <PR#> → git pull → Implement → Push
+    ↓ NO
+User says "current branch"? → YES → Implement directly
+    ↓ NO
+git checkout main && git pull → git checkout -b feature/name → Implement
 ```
 
-## Best Practices
+## For New Work
 
-### DO:
-- Pull latest changes before starting
-- Use descriptive branch names (`feature/user-auth`, `fix/login-error`)
-- Verify current branch with `git branch --show-current`
-- Follow existing code patterns and conventions
-- Make focused, incremental changes
-
-### DON'T:
-- Work directly on main/master without explicit request
-- Create new branch for existing PR work
-- Make changes without checking current state
-- Add unrequested features or refactorings
-- Skip pulling latest changes
-
-## Example Workflows
-
-**New Feature**:
-```markdown
-User: "Add user registration"
-→ git checkout main && git pull origin main
-→ git checkout -b feature/user-registration
-→ Implement feature
+```bash
+git checkout main && git pull origin main
+git checkout -b feature/descriptive-name  # or: fix/, refactor/, docs/
 ```
 
-**Update Existing PR**:
-```markdown
-User: "Add changes to PR #123"
-→ gh pr checkout 123 && git pull
-→ Implement changes
-→ git push origin <branch-name>
+## For Existing PR
+
+```bash
+gh pr checkout <PR-number>
+git pull origin <branch-name>
+# Make changes
+git push origin <branch-name>
 ```
 
-**Explicit Current Branch**:
-```markdown
-User: "Work on current branch, add feature"
-→ Implement directly (no branch operations)
-```
+## DO / DON'T
 
-## Integration with Other Skills
+**DO**: Pull latest before starting, use descriptive branch names, verify current branch, follow existing patterns
 
-- After branch setup, use **test-driven-approach** to implement tests first
-- During implementation, use **debugging-process** when investigating existing code
-- When creating PR, use **pr-description-format** for PR description
+**DON'T**: Push to main/develop directly, create new branch for existing PR work, skip pulling latest

--- a/plugins/dev-guidelines/skills/pr-description-format/SKILL.md
+++ b/plugins/dev-guidelines/skills/pr-description-format/SKILL.md
@@ -1,33 +1,12 @@
 ---
 name: PR Description Format
-description: Use this skill when creating GitHub pull requests or using 'gh pr create'. Provides Japanese PR description format (概要/変更の背景/変更詳細) with professional です/ます style.
+description: Provides Japanese PR description format and workflow requirements for GitHub pull requests. Use this skill when creating PRs or using 'gh pr create'.
 version: 1.0.0
 ---
 
 # GitHub PR Description Format
 
 ## Format: What / Why / How
-
-Use this three-section structure for PR descriptions:
-
-### 概要 (Overview) - WHAT
-Brief summary of the changes
-- Concise description of what was changed
-- Focus on main changes and their impact
-
-### 変更の背景 (Background) - WHY
-Reason and motivation for the changes
-- Why this change was necessary
-- Problem or requirement that triggered this work
-- Context for reviewers
-
-### 変更詳細 (Details) - HOW
-Specific implementation details
-- List specific changes made
-- Technical decisions and approach
-- Testing approach if relevant
-
-## Template
 
 ```markdown
 ## 概要
@@ -37,37 +16,16 @@ Specific implementation details
 [Why this change was needed]
 
 ## 変更詳細
-- [Specific change 1]
-- [Specific change 2]
-- [Implementation details]
+- [Specific changes and implementation details]
 ```
 
 ## Important Notes
 
-- **Use professional Japanese** (です/ます) for PR descriptions, NOT character voice
-- Write for code reviewers to understand changes quickly
-- Focus on clarity and completeness
-- Include relevant context and rationale
+- ロールプレイせず、通常のです/ます調で記述する
+- If "Why" is unclear, ask user before creating PR
 
-## PR Workflow Requirements
+## Workflow Requirements
 
-### 1. Always Start with Draft PR
-```bash
-gh pr create --draft
-```
-Only switch to open state when explicitly instructed to request review:
-```bash
-gh pr ready
-```
-
-### 2. Clarify "Why" Before Creating PR
-If the reason for changes is not clear or not provided by the user:
-- **ALWAYS ask the user for clarification** before creating the PR
-- Include business context, problem being solved, or improvement being made
-- Ensure reviewers can understand both implementation and motivation
-
-### 3. Update PR Description on New Commits
-When pushing new commits to an existing PR:
-- Always update the PR description to reflect current state: `gh pr edit --body`
-- Ensure description accurately represents ALL changes, not just initial implementation
-- Base the update on latest commit history and changes
+1. **Always start with Draft PR**: `gh pr create --draft`
+2. **Switch to open only when requested**: `gh pr ready`
+3. **Update description on new commits**: `gh pr edit --body` to reflect current state

--- a/plugins/dev-guidelines/skills/test-driven-approach/SKILL.md
+++ b/plugins/dev-guidelines/skills/test-driven-approach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Test-Driven Approach
-description: Use this skill when implementing tests, practicing TDD, creating test cases, or planning test strategy. Reference specific methodologies (t_wada's TDD, Kent Beck's TDD) and provide test skeleton before implementation.
+description: Provides TDD methodology guidance based on established practices (t_wada, Kent Beck). Use this skill when implementing tests, practicing TDD, creating test cases, or planning test strategy.
 version: 1.0.0
 ---
 
@@ -8,98 +8,35 @@ version: 1.0.0
 
 ## Core Principles
 
-### 1. Reference Specific Methodologies
+1. **Reference Specific Methodologies**: Cite t_wada's TDD, Kent Beck's TDD, or framework-specific practices (Jest, pytest, RSpec). Avoid generic "best practices".
+2. **Test Skeleton First**: Provide structure before implementation to identify edge cases early.
+3. **Red-Green-Refactor**: Write failing test → Minimal code to pass → Refactor
 
-When implementing tests, cite **concrete methodologies**:
-- **t_wada's TDD** - Test-Driven Development approach by t_wada
-- **Kent Beck's Test-Driven Development** - Classic TDD methodology
-- Framework-specific best practices (Jest, pytest, RSpec, etc.)
-
-Generic "best practices" are less effective than specific, established approaches.
-
-### 2. Test Skeleton First
-
-Provide the **structure** of test cases before implementation:
+## Test Skeleton Example
 
 ```typescript
 describe('UserAuthentication', () => {
   describe('login', () => {
-    it('should successfully login with valid credentials', () => {
-      // TODO: Implement
-    });
-
-    it('should reject invalid credentials', () => {
-      // TODO: Implement
-    });
-
-    it('should handle missing credentials', () => {
-      // TODO: Implement
-    });
-
-    it('should lock account after multiple failed attempts', () => {
-      // TODO: Implement
-    });
-  });
-
-  describe('logout', () => {
-    it('should clear session on logout', () => {
-      // TODO: Implement
-    });
+    it('should successfully login with valid credentials', () => {});
+    it('should reject invalid credentials', () => {});
+    it('should lock account after multiple failed attempts', () => {});
   });
 });
 ```
 
-**Benefits**: Structure guides implementation, identifies edge cases early, ensures comprehensive coverage, facilitates scope discussion.
+## What to Test
 
-### 3. Red-Green-Refactor Cycle
-
-1. **Red**: Write a failing test (feature doesn't exist yet)
-2. **Green**: Write minimal code to make test pass
-3. **Refactor**: Improve code while keeping tests green
-
-## Test Case Design
-
-### What to Test
 - **Happy path**: Expected usage scenarios
 - **Edge cases**: Boundary conditions, empty inputs
 - **Error cases**: Invalid inputs, error handling
-- **Integration points**: Interaction with dependencies
 
-### Test Naming
-Use descriptive names that explain the expected behavior:
+## Test Naming
 
 ✅ `should return 404 when user not found`
-✅ `should validate email format before saving`
-❌ `works correctly`
-❌ `test1`
+❌ `works correctly` / `test1`
 
-## Example Workflow
+## DO / DON'T
 
-```markdown
-1. "マスター、t_wadaのTDDアプローチを使ってテストを実装するね"
-2. "まず、テストケースの構造を作るよ"
-   [Show test skeleton with describe/it blocks]
-3. "これでカバーすべきケースは揃っているかな？"
-4. "それじゃあ、各テストケースを実装していくね"
-   [Implement tests following Red-Green-Refactor]
-```
+**DO**: Reference specific methodologies, provide skeleton first, use descriptive names, test behavior not implementation
 
-## Best Practices
-
-### DO:
-- Reference specific methodologies (not generic "best practices")
-- Provide test skeleton before details
-- Write tests before implementation (in TDD)
-- Use descriptive test names
-- Test behavior, not implementation details
-
-### DON'T:
-- Use vague "best practices" without specifics
-- Jump to implementation without structure
-- Test internal implementation details
-- Create dependent tests
-
-## Integration with Other Skills
-
-- Works with **implementation-workflow** for proper branch setup before writing tests
-- Complements **debugging-process** (write failing test → investigate → fix → verify)
+**DON'T**: Use vague best practices, skip structure, test implementation details, create dependent tests

--- a/plugins/dev-guidelines/skills/web-tools/SKILL.md
+++ b/plugins/dev-guidelines/skills/web-tools/SKILL.md
@@ -1,57 +1,35 @@
 ---
 name: Web Research Tools
-description: Use this skill when performing web scraping, browser automation, or documentation tasks. Use Playwright MCP for web information retrieval and Obsidian MCP for note-taking.
+description: Specifies tool selection rules for web operations and documentation. Use this skill when performing web scraping, browser automation, GitHub information retrieval, or documentation tasks.
 version: 1.0.0
 ---
 
 # Web Research and Documentation Tools
 
-## Web Information Retrieval: Playwright MCP
+## Tool Selection Rules
 
-For web scraping and browser automation:
-- **Tool**: https://github.com/microsoft/playwright-mcp
-- **Use for**: Navigating pages, interacting with elements, extracting data from dynamic websites, taking screenshots, handling authentication flows
+| Task | Tool | Prohibited |
+|------|------|------------|
+| Web scraping / Browser automation | Playwright MCP | curl, custom solutions |
+| GitHub info (PR, Issue, Actions) | `gh` command | WebFetch, WebSearch |
+| App behavior verification | Playwright MCP (`mcp__playwright__browser_*`) | curl, WebFetch |
+| Documentation / Notes | Obsidian MCP | - |
 
-## Documentation and Notes: Obsidian MCP
+## GitHub Operations
 
-For knowledge management and documentation:
-- **Tool**: https://github.com/jacksteamdev/obsidian-mcp-tools
-- **Pre-configured** in the environment
-- **Use for**: Organizing research findings, creating interconnected notes, building knowledge bases, markdown-based documentation
+```bash
+gh pr view/list    # PR information
+gh issue view/list # Issue information
+gh repo view       # Repository information
+gh run list/view   # GitHub Actions
+```
 
-## Best Practices
+## Playwright Operations
 
-### Choose the Right Tool
-- **Playwright MCP** for web data retrieval
-- **Obsidian** for documentation and notes
-- **Combine both** for comprehensive research workflows (gather with Playwright → organize with Obsidian)
+- Navigation: `mcp__playwright__browser_navigate`
+- Interaction: `mcp__playwright__browser_click`, `mcp__playwright__browser_type`
+- Screenshots: `mcp__playwright__browser_take_screenshot`
 
-### Efficient Workflows
-1. Use Playwright to gather information from web sources
-2. Use Obsidian to organize and document findings
-3. Create reproducible research processes
+## Workflow
 
-## Important Notes
-
-- Always prefer Playwright MCP over custom web scraping solutions
-- Leverage pre-configured Obsidian tools when available
-- Consider data privacy and website terms of service
-- Document your research process for reproducibility
-
-## Required Tool Usage Rules
-
-### GitHub Information Retrieval
-**Always use gh command when retrieving information from GitHub:**
-- Pull Request information: `gh pr view`, `gh pr list`
-- Issue information: `gh issue view`, `gh issue list`
-- Repository information: `gh repo view`
-- GitHub Actions information: `gh run list`, `gh run view`
-- **Prohibited:** Do not use WebFetch or WebSearch for GitHub information
-
-### Application Behavior Verification
-**Always use Playwright for web application behavior verification:**
-- UI interaction testing: Use `mcp__playwright__browser_*` tool suite
-- Screen screenshots: `mcp__playwright__browser_take_screenshot`
-- Element operations: `mcp__playwright__browser_click`, `mcp__playwright__browser_type`
-- Page navigation verification: `mcp__playwright__browser_navigate`
-- **Prohibited:** Do not use curl or WebFetch for application behavior verification
+1. Gather with Playwright → 2. Organize with Obsidian


### PR DESCRIPTION
## 概要
dev-guidelinesプラグインの各スキルについて、descriptionの形式を統一し、内容を簡素化しました。

## 変更の背景
スキルのdescriptionに「利用するべき局面の判断」以外の詳細な手順情報が含まれていたため、Claude Codeのベストプラクティスに従い「What（目的）+ When（トリガー条件）」形式に統一する必要がありました。

## 変更詳細
- **description形式の統一**: 全6スキルのdescriptionを「目的 + トリガー条件」形式に修正
- **内容の簡素化**: 情報量を維持しつつ、各スキルの行数を約40-60%削減
  - debugging-process: 78行 → 47行
  - design-alternatives: 84行 → 41行
  - test-driven-approach: 106行 → 43行
  - implementation-workflow: 110行 → 48行
  - pr-description-format: 74行 → 32行
  - web-tools: 58行 → 36行
- **文言修正**: pr-description-formatの「Use professional Japanese」を「ロールプレイせず、通常のです/ます調で記述する」に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)