### PR TITLE
refactor: update skills to best practices and translate to English

### DIFF
--- a/plugins/dev-guidelines/skills/debugging-process/SKILL.md
+++ b/plugins/dev-guidelines/skills/debugging-process/SKILL.md
@@ -1,17 +1,18 @@
 ---
-name: Debugging Process
+name: debugging-process
 description: Provides systematic debugging methodology for thorough root cause analysis with evidence-based investigation. Use this skill when investigating code, analyzing bugs, tracing errors, or understanding unexpected behavior.
-version: 1.0.0
 ---
 
-# Debugging and Root Cause Analysis
+# Debugging Process
 
-## Core Principles
+## Instructions
+
+### Core Principles
 
 1. **Real-Time Reporting**: Share findings immediately with `file:line` references. Report "Checking [X] at [location]" → "Found [Y], suggests [Z]"
 2. **Root Cause First**: Use 5 Whys technique. Fix the source, not symptoms.
 
-## Investigation Pattern
+### Investigation Pattern
 
 ```
 1. "Investigating [X] by checking [Y]"
@@ -20,7 +21,22 @@ version: 1.0.0
 4. Root cause identified → Apply fix
 ```
 
-## 5 Whys Example
+### Anti-Patterns
+
+- Adding try-catch without understanding why it throws
+- Null-checks everywhere instead of understanding cause
+- Guessing solutions (e.g., setTimeout hoping it helps)
+- Presenting only conclusions without evidence
+
+### DO / DON'T
+
+**DO**: Use `file:line` references, share evidence progressively, trace to origin, explain causal chain
+
+**DON'T**: Rush to fix, hide investigation process, fix symptoms not causes
+
+## Examples
+
+### 5 Whys Example
 
 ```
 Problem: App crashes on submit
@@ -31,16 +47,3 @@ Why? → Component mounts before API response
 Why? → Race condition
 → Fix: Correct initialization order
 ```
-
-## Anti-Patterns
-
-- Adding try-catch without understanding why it throws
-- Null-checks everywhere instead of understanding cause
-- Guessing solutions (e.g., setTimeout hoping it helps)
-- Presenting only conclusions without evidence
-
-## DO / DON'T
-
-**DO**: Use `file:line` references, share evidence progressively, trace to origin, explain causal chain
-
-**DON'T**: Rush to fix, hide investigation process, fix symptoms not causes

--- a/plugins/dev-guidelines/skills/design-alternatives/SKILL.md
+++ b/plugins/dev-guidelines/skills/design-alternatives/SKILL.md
@@ -1,23 +1,32 @@
 ---
-name: Design Alternatives
+name: design-alternatives
 description: Guides structured evaluation of design options with trade-off analysis. Use this skill when choosing architectures, selecting technologies, evaluating implementation approaches, or making design decisions.
-version: 1.0.0
 ---
 
-# Design and Architecture Decision Process
+# Design Alternatives
 
-## Core Principle
+## Instructions
+
+### Core Principle
 
 **Always propose 2-3 alternatives** with comprehensive analysis for each.
 
-## For Each Alternative
+### For Each Alternative
 
 1. **Advantages**: Benefits and problems it solves well
 2. **Disadvantages**: Drawbacks, limitations, complexities
 3. **Reasoning**: Why this is a good or poor choice
 4. **Future Scenarios**: When it breaks down, scalability concerns
 
-## Template
+### DO / DON'T
+
+**DO**: Think broadly, consider long-term implications, make trade-offs explicit, document reasoning
+
+**DON'T**: Rush to first solution, present only one option, ignore future scalability
+
+## Examples
+
+### Template
 
 ```markdown
 ## Option 1: [Approach Name]
@@ -32,9 +41,3 @@ version: 1.0.0
 ## Recommendation
 [Based on requirements and future considerations]
 ```
-
-## DO / DON'T
-
-**DO**: Think broadly, consider long-term implications, make trade-offs explicit, document reasoning
-
-**DON'T**: Rush to first solution, present only one option, ignore future scalability

--- a/plugins/dev-guidelines/skills/implementation-workflow/SKILL.md
+++ b/plugins/dev-guidelines/skills/implementation-workflow/SKILL.md
@@ -1,18 +1,19 @@
 ---
-name: Implementation Workflow
+name: implementation-workflow
 description: Ensures proper Git branch management and PR workflow for code changes. Use this skill when implementing new features, bug fixes, or any code modifications in a Git repository.
-version: 1.0.0
 ---
 
-# Code Implementation Workflow
+# Implementation Workflow
 
-## CRITICAL: Never Push to Default Branches
+## Instructions
+
+### CRITICAL: Never Push to Default Branches
 
 ❌ **PROHIBITED**: `git push origin main/develop/master`
 
 ALL changes must go through Pull Requests. No exceptions.
 
-## Workflow Decision
+### Workflow Decision
 
 ```
 Start Implementation
@@ -24,14 +25,22 @@ User says "current branch"? → YES → Implement directly
 git checkout main && git pull → git checkout -b feature/name → Implement
 ```
 
-## For New Work
+### DO / DON'T
+
+**DO**: Pull latest before starting, use descriptive branch names, verify current branch, follow existing patterns
+
+**DON'T**: Push to main/develop directly, create new branch for existing PR work, skip pulling latest
+
+## Examples
+
+### For New Work
 
 ```bash
 git checkout main && git pull origin main
 git checkout -b feature/descriptive-name  # or: fix/, refactor/, docs/
 ```
 
-## For Existing PR
+### For Existing PR
 
 ```bash
 gh pr checkout <PR-number>
@@ -39,9 +48,3 @@ git pull origin <branch-name>
 # Make changes
 git push origin <branch-name>
 ```
-
-## DO / DON'T
-
-**DO**: Pull latest before starting, use descriptive branch names, verify current branch, follow existing patterns
-
-**DON'T**: Push to main/develop directly, create new branch for existing PR work, skip pulling latest

--- a/plugins/dev-guidelines/skills/pr-description-format/SKILL.md
+++ b/plugins/dev-guidelines/skills/pr-description-format/SKILL.md
@@ -1,31 +1,34 @@
 ---
-name: PR Description Format
-description: Provides Japanese PR description format and workflow requirements for GitHub pull requests. Use this skill when creating PRs or using 'gh pr create'.
-version: 1.0.0
+name: pr-description-format
+description: Provides PR description format and workflow requirements for GitHub pull requests. Use this skill when creating PRs or using 'gh pr create'.
 ---
 
-# GitHub PR Description Format
+# PR Description Format
 
-## Format: What / Why / How
+## Instructions
 
-```markdown
-## 概要
-[Brief summary of what was changed]
+### Important Notes
 
-## 変更の背景
-[Why this change was needed]
+- Do not use roleplay; use normal professional tone.
+- If "Why" is unclear, ask user before creating PR.
 
-## 変更詳細
-- [Specific changes and implementation details]
-```
-
-## Important Notes
-
-- ロールプレイせず、通常のです/ます調で記述する
-- If "Why" is unclear, ask user before creating PR
-
-## Workflow Requirements
+### Workflow Requirements
 
 1. **Always start with Draft PR**: `gh pr create --draft`
 2. **Switch to open only when requested**: `gh pr ready`
 3. **Update description on new commits**: `gh pr edit --body` to reflect current state
+
+## Examples
+
+### Format: What / Why / How
+
+```markdown
+## Summary
+[Brief summary of what was changed]
+
+## Background
+[Why this change was needed]
+
+## Details
+- [Specific changes and implementation details]
+```

--- a/plugins/dev-guidelines/skills/test-driven-approach/SKILL.md
+++ b/plugins/dev-guidelines/skills/test-driven-approach/SKILL.md
@@ -1,18 +1,38 @@
 ---
-name: Test-Driven Approach
+name: test-driven-approach
 description: Provides TDD methodology guidance based on established practices (t_wada, Kent Beck). Use this skill when implementing tests, practicing TDD, creating test cases, or planning test strategy.
-version: 1.0.0
 ---
 
-# Test-Driven Development Methodology
+# Test-Driven Approach
 
-## Core Principles
+## Instructions
+
+### Core Principles
 
 1. **Reference Specific Methodologies**: Cite t_wada's TDD, Kent Beck's TDD, or framework-specific practices (Jest, pytest, RSpec). Avoid generic "best practices".
 2. **Test Skeleton First**: Provide structure before implementation to identify edge cases early.
 3. **Red-Green-Refactor**: Write failing test → Minimal code to pass → Refactor
 
-## Test Skeleton Example
+### What to Test
+
+- **Happy path**: Expected usage scenarios
+- **Edge cases**: Boundary conditions, empty inputs
+- **Error cases**: Invalid inputs, error handling
+
+### Test Naming
+
+✅ `should return 404 when user not found`
+❌ `works correctly` / `test1`
+
+### DO / DON'T
+
+**DO**: Reference specific methodologies, provide skeleton first, use descriptive names, test behavior not implementation
+
+**DON'T**: Use vague best practices, skip structure, test implementation details, create dependent tests
+
+## Examples
+
+### Test Skeleton Example
 
 ```typescript
 describe('UserAuthentication', () => {
@@ -23,20 +43,3 @@ describe('UserAuthentication', () => {
   });
 });
 ```
-
-## What to Test
-
-- **Happy path**: Expected usage scenarios
-- **Edge cases**: Boundary conditions, empty inputs
-- **Error cases**: Invalid inputs, error handling
-
-## Test Naming
-
-✅ `should return 404 when user not found`
-❌ `works correctly` / `test1`
-
-## DO / DON'T
-
-**DO**: Reference specific methodologies, provide skeleton first, use descriptive names, test behavior not implementation
-
-**DON'T**: Use vague best practices, skip structure, test implementation details, create dependent tests

--- a/plugins/dev-guidelines/skills/web-tools/SKILL.md
+++ b/plugins/dev-guidelines/skills/web-tools/SKILL.md
@@ -1,12 +1,13 @@
 ---
-name: Web Research Tools
+name: web-tools
 description: Specifies tool selection rules for web operations and documentation. Use this skill when performing web scraping, browser automation, GitHub information retrieval, or documentation tasks.
-version: 1.0.0
 ---
 
-# Web Research and Documentation Tools
+# Web Research Tools
 
-## Tool Selection Rules
+## Instructions
+
+### Tool Selection Rules
 
 | Task | Tool | Prohibited |
 |------|------|------------|
@@ -15,7 +16,13 @@ version: 1.0.0
 | App behavior verification | Playwright MCP (`mcp__playwright__browser_*`) | curl, WebFetch |
 | Documentation / Notes | Obsidian MCP | - |
 
-## GitHub Operations
+### Workflow
+
+1. Gather with Playwright → 2. Organize with Obsidian
+
+## Examples
+
+### GitHub Operations
 
 ```bash
 gh pr view/list    # PR information
@@ -24,12 +31,8 @@ gh repo view       # Repository information
 gh run list/view   # GitHub Actions
 ```
 
-## Playwright Operations
+### Playwright Operations
 
 - Navigation: `mcp__playwright__browser_navigate`
 - Interaction: `mcp__playwright__browser_click`, `mcp__playwright__browser_type`
 - Screenshots: `mcp__playwright__browser_take_screenshot`
-
-## Workflow
-
-1. Gather with Playwright → 2. Organize with Obsidian

--- a/plugins/issue-resolver/skills/resolve-issue/SKILL.md
+++ b/plugins/issue-resolver/skills/resolve-issue/SKILL.md
@@ -1,105 +1,86 @@
-# Issue解決スキル
+---
+name: resolve-issue
+description: Provides a systematic workflow for resolving GitHub Issues. Use this skill when assigned a GitHub Issue or when delegated by the Issue Auto-resolver.
+---
 
-このスキルは、GitHub Issueを体系的に解決するためのワークフローを提供します。
+# Resolve Issue
 
-## スキルの目的
+## Instructions
 
-GitHub Issueの種別を判定し、種別ごとに適切な解決プロセスを適用することで、一貫性のある高品質な問題解決を実現します。
+### Purpose
 
-## 使用タイミング
+Achieve consistent, high-quality problem resolution by determining the GitHub Issue type and applying the appropriate resolution process for each type.
 
-- GitHub Issueの解決を依頼されたとき
-- Issue Auto-resolverから処理を委譲されたとき
+### Usage Timing
 
-## 解決プロセス
+- When requested to resolve a GitHub Issue
+- When delegated processing by the Issue Auto-resolver
 
-### ステップ1: Issue種別の判定とラベル付与
+### Resolution Process
 
-まず、Issueに `type:*` ラベルが付与されているか確認してください。
+#### Step 1: Determine Issue Type and Apply Label
 
-**ラベルが付いていない場合:**
+First, check if the Issue has a `type:*` label.
 
-Issueのタイトルと本文を読んで、以下の6種類から適切な種別を判定し、対応するラベルを付与してください：
+**If no label is present:**
 
-- `type:bug` - バグ、エラー、不具合の修正
-- `type:feature` - 新機能の追加
-- `type:investigation` - 調査、分析タスク
-- `type:refactoring` - コードのリファクタリング
-- `type:documentation` - ドキュメントの更新
-- `type:enhancement` - 既存機能の改善
+Read the Issue title and body, determine the appropriate type from the following 6 categories, and apply the corresponding label:
 
-判定が難しい場合は、デフォルトで `type:feature` を付与してください。
+- `type:bug` - Fix bugs, errors, or defects
+- `type:feature` - Add new features
+- `type:investigation` - Investigation or analysis tasks
+- `type:refactoring` - Code refactoring
+- `type:documentation` - Update documentation
+- `type:enhancement` - Improve existing features
 
-### ステップ2: 種別ごとの詳細手順に従う
+If it is difficult to determine, apply `type:feature` by default.
 
-Issueの種別が判定できたら、以下のタイミングで対応する詳細手順ファイルを参照してください：
+#### Step 2: Follow Detailed Instructions for Each Type
 
-#### type:bug の場合
-**参照タイミング:** バグ修正の具体的な手順を確認する必要があるとき
+Once the Issue type is determined, refer to the corresponding detailed instruction file at the following times:
 
-詳細な手順は以下のファイルを参照してください：
-```
-{plugin_base_path}/issue-types/bug.md
-```
+**type:bug**
+- **When to refer:** When you need to check specific steps for bug fixing.
+- **Reference file:** `{plugin_base_path}/issue-types/bug.md`
 
-#### type:feature の場合
-**参照タイミング:** 新機能実装の具体的な手順を確認する必要があるとき
+**type:feature**
+- **When to refer:** When you need to check specific steps for implementing new features.
+- **Reference file:** `{plugin_base_path}/issue-types/feature.md`
 
-詳細な手順は以下のファイルを参照してください：
-```
-{plugin_base_path}/issue-types/feature.md
-```
+**type:investigation**
+- **When to refer:** When you need to check specific steps for investigation tasks.
+- **Reference file:** `{plugin_base_path}/issue-types/investigation.md`
 
-#### type:investigation の場合
-**参照タイミング:** 調査タスクの具体的な手順を確認する必要があるとき
+**type:refactoring**
+- **When to refer:** When you need to check specific steps for refactoring.
+- **Reference file:** `{plugin_base_path}/issue-types/refactoring.md`
 
-詳細な手順は以下のファイルを参照してください：
-```
-{plugin_base_path}/issue-types/investigation.md
-```
+**type:documentation**
+- **When to refer:** When you need to check specific steps for updating documentation.
+- **Reference file:** `{plugin_base_path}/issue-types/documentation.md`
 
-#### type:refactoring の場合
-**参照タイミング:** リファクタリングの具体的な手順を確認する必要があるとき
+**type:enhancement**
+- **When to refer:** When you need to check specific steps for improving existing features.
+- **Reference file:** `{plugin_base_path}/issue-types/enhancement.md`
 
-詳細な手順は以下のファイルを参照してください：
-```
-{plugin_base_path}/issue-types/refactoring.md
-```
+### Common Guidelines
 
-#### type:documentation の場合
-**参照タイミング:** ドキュメント更新の具体的な手順を確認する必要があるとき
+Important notes common to all Issue types:
 
-詳細な手順は以下のファイルを参照してください：
-```
-{plugin_base_path}/issue-types/documentation.md
-```
+**Code Quality**
+- Check existing code patterns before implementation and maintain consistency.
+- Avoid excessive feature additions or unnecessary refactoring.
 
-#### type:enhancement の場合
-**参照タイミング:** 既存機能改善の具体的な手順を確認する必要があるとき
+**Git Operations**
+- Manage branches according to the implementation workflow (implementation-workflow skill).
+- Keep commit messages clear and concise.
 
-詳細な手順は以下のファイルを参照してください：
-```
-{plugin_base_path}/issue-types/enhancement.md
-```
+**Creating PRs**
+- Use the `gh pr` command when creating PRs.
+- Write the PR title, comments, and description in Japanese (unless otherwise specified).
+- Include an appropriate summary of changes in the PR description.
 
-## 共通ガイドライン
+### Notes
 
-すべてのIssue種別に共通する重要な注意事項：
-
-### コード品質
-- 実装前に既存のコードパターンを確認し、一貫性を保つこと
-- 過度な機能追加や不要なリファクタリングは避けること
-
-### Git操作
-- 実装ワークフロー（implementation-workflow skill）に従ってブランチ管理を行うこと
-- コミットメッセージは明確で簡潔にすること
-
-### PR作成
-- PRを作成するときは `gh pr` コマンドを使うこと
-- PRのタイトル、コメント、descriptionは日本語で記載すること
-- PR説明には適切な変更内容の要約を含めること
-
-## 注意事項
-
-- `{plugin_base_path}` は、このスキルがインストールされているプラグインのベースパスを指します
-- 実際にファイルを参照する際は、適切なパスに置き換えて参照してください
+- `{plugin_base_path}` refers to the base path of the plugin where this skill is installed.
+- When actually referencing files, replace it with the appropriate path.


### PR DESCRIPTION
## Summary
Updated `SKILL.md` files in `plugins/dev-guidelines` and `plugins/issue-resolver` to align with Claude Code best practices and translated instructions to English.

## Changes
- Updated frontmatter to use lowercase names and remove version fields.
- Structured content under `## Instructions` and `## Examples`.
- Translated Japanese content in `resolve-issue` and `pr-description-format` to English.

## Notes
- `issue-types/*.md` files referenced by `resolve-issue` were NOT translated as per plan.