### PR TITLE
feat: Add code-like-prompt plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,6 +48,19 @@
       "license": "MIT",
       "keywords": ["github", "issue", "workflow", "automation"],
       "category": "development"
+    },
+    {
+      "name": "code-like-prompt",
+      "source": "./plugins/code-like-prompt",
+      "description": "Collection of commands that execute code-like prompts demonstrating programming concepts through interactive scenarios",
+      "version": "0.1.0",
+      "author": {
+        "name": "kokuyouwind",
+        "url": "https://github.com/kokuyouwind"
+      },
+      "license": "MIT",
+      "keywords": ["education", "examples", "programming", "jokes"],
+      "category": "education"
     }
   ]
 }

--- a/plugins/code-like-prompt/.claude-plugin/plugin.json
+++ b/plugins/code-like-prompt/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "code-like-prompt",
+  "version": "0.1.0",
+  "description": "Collection of commands that execute code-like prompts demonstrating programming concepts",
+  "author": {
+    "name": "kokuyouwind",
+    "email": "kokuyouwind@gmail.com"
+  },
+  "keywords": ["education", "examples", "programming", "jokes"],
+  "license": "MIT"
+}

--- a/plugins/code-like-prompt/README.md
+++ b/plugins/code-like-prompt/README.md
@@ -1,0 +1,81 @@
+# code-like-prompt
+
+A Claude Code plugin that provides educational examples of code-like prompts demonstrating programming concepts through interactive scenarios.
+
+## Overview
+
+This plugin contains a collection of commands that execute code-like prompts. Each command demonstrates how different interpretations of the same instructions can lead to different outcomes, similar to programming logic.
+
+## Installation
+
+Install from the kokuyouwind-plugins marketplace:
+
+```bash
+/plugin marketplace add kokuyouwind/claude-plugins
+/plugin install code-like-prompt@kokuyouwind-plugins
+```
+
+## Commands
+
+### `/code-like-prompt:01-shopping-request`
+
+**Description**: コード風プロンプト例1 牛乳ジョーク:妻の依頼
+
+Demonstrates the wife's correct intention in the classic "milk joke" - a programming humor example about conditional logic.
+
+**Logic**:
+- Buy 1 milk
+- If eggs exist, buy 6 eggs
+
+**Arguments**:
+- `--milk-stock`: Milk stock amount (optional, will ask if not provided)
+- `--egg-stock`: Egg stock amount (optional, will ask if not provided)
+
+**Example**:
+```bash
+/code-like-prompt:01-shopping-request --milk-stock=5 --egg-stock=12
+```
+
+### `/code-like-prompt:01-shopping-misunderstanding`
+
+**Description**: コード風プロンプト例1 牛乳ジョーク:夫の理解
+
+Demonstrates the husband's misunderstanding in the classic "milk joke" - showing how ambiguous conditional logic can be misinterpreted.
+
+**Logic**:
+- Set milk amount to 1
+- If eggs exist, set milk amount to 6
+- Buy milk with the determined amount
+
+**Arguments**:
+- `--milk-stock`: Milk stock amount (optional, will ask if not provided)
+- `--egg-stock`: Egg stock amount (optional, will ask if not provided)
+
+**Example**:
+```bash
+/code-like-prompt:01-shopping-misunderstanding --milk-stock=5 --egg-stock=12
+```
+
+## The Milk Joke
+
+This plugin is based on a classic programmer joke:
+
+> Wife: "Buy 1 milk. If there are eggs, buy 6."
+>
+> Programmer husband returns with 6 milks.
+>
+> Wife: "Why did you buy 6 milks?"
+>
+> Husband: "Because there were eggs!"
+
+The joke illustrates how the same instruction can be interpreted differently:
+- **Wife's intention**: Buy 1 milk, and if eggs are available, also buy 6 eggs
+- **Husband's interpretation**: Buy 1 milk, but if eggs are available, buy 6 milks instead
+
+## Version
+
+0.1.0
+
+## License
+
+MIT

--- a/plugins/code-like-prompt/commands/01-shopping-misunderstanding.md
+++ b/plugins/code-like-prompt/commands/01-shopping-misunderstanding.md
@@ -1,0 +1,23 @@
+---
+description: コード風プロンプト例1 牛乳ジョーク:夫の理解
+argument-hint: "[--milk-stock=N] [--egg-stock=N]"
+---
+
+Execute the following code. Output only what puts() commands specify. Do not show any explanations, code, variables, or other messages.
+
+```
+if Milk.stock.nil?
+  puts("Input: Milk")
+  Milk.stock = gets
+end
+if Egg.stock.nil?
+  puts("Input: Egg")
+  Egg.stock = gets
+end
+
+milk_amount = 1
+if Egg.exists?
+  milk_amount = 6
+end
+puts("Bought #{milk_amount} milks.")
+```

--- a/plugins/code-like-prompt/commands/01-shopping-request.md
+++ b/plugins/code-like-prompt/commands/01-shopping-request.md
@@ -1,0 +1,22 @@
+---
+description: コード風プロンプト例1 牛乳ジョーク:妻の依頼
+argument-hint: "[--milk-stock=N] [--egg-stock=N]"
+---
+
+Execute the following code. Output only what puts() commands specify. Do not show any explanations, code, variables, or other messages.
+
+```
+if Milk.stock.nil?
+  puts("Input: Milk")
+  Milk.stock = gets
+end
+if Egg.stock.nil?
+  puts("Input: Egg")
+  Egg.stock = gets
+end
+
+puts("Bought 1 milk.")
+if Egg.exists?
+  puts("Bought 6 eggs.")
+end
+```


### PR DESCRIPTION
## 概要
code-like-promptプラグインを追加しました。プログラミングコンセプトを教育的に示すコード風プロンプトを実行するコマンド集です。

## 変更の背景
コード風のプロンプトがどの程度忠実に動作するかを試すため、教育的な例としてプラグインを作成しました。牛乳ジョーク（条件分岐の解釈違い）を題材に、同じ指示でも解釈によって異なる結果になることを実演します。

## 変更詳細
- 新しいプラグイン `code-like-prompt` を追加
  - plugin.json: プラグインメタデータ定義
  - README.md: 使い方とコマンド説明
  - 2つのコマンドを実装:
    - `01-shopping-request`: 妻の正しい意図（卵があれば卵を6つ買う）
    - `01-shopping-misunderstanding`: 夫の誤解（卵があれば牛乳を6つ買う）
- Ruby風の疑似コードでプロンプトを記述
- `puts()` で明示的に出力を指定
- `gets` でユーザー入力を取得
- 引数による在庫指定またはインタラクティブな入力に対応
- marketplace.jsonに登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)