### PR TITLE
fix: Remove explicit skills field from issue-resolver plugin.json

### DIFF
--- a/plugins/issue-resolver/.claude-plugin/plugin.json
+++ b/plugins/issue-resolver/.claude-plugin/plugin.json
@@ -5,8 +5,5 @@
   "author": {
     "name": "kokuyouwind",
     "url": "https://github.com/kokuyouwind"
-  },
-  "skills": [
-    "resolve-issue"
-  ]
+  }
 }


### PR DESCRIPTION
## 概要
issue-resolver プラグインの plugin.json から明示的な skills フィールドを削除しました。

## 変更の背景
プラグイン有効化時に以下のエラーが発生していました：

```
✘ issue-resolver@kokuyouwind-plugins
   Plugin issue-resolver has an invalid manifest file
   Validation errors: skills.0: Invalid input: must start with "./"
```

skills 配列の値が `"resolve-issue"` という相対パスではない形式になっており、Claude Code のプラグイン仕様（"./" で始まる必要がある）に違反していました。

## 変更詳細
- `plugins/issue-resolver/.claude-plugin/plugin.json` から `skills` フィールドを削除
- auto-discovery に依存する形に変更（他のプラグイン `dev-guidelines`, `rbs-goose` と同じパターン）
- `skills/` ディレクトリ内のスキルファイルは自動検出されるため、機能に影響はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)