### PR TITLE
refactor: issue-resolver スキルの英語化と dev-guidelines 連携

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh label:*),Bash(gh pr:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh label:*),Bash(gh pr:*),Skill(*)"'
 

--- a/plugins/issue-resolver/skills/resolve-issue/SKILL.md
+++ b/plugins/issue-resolver/skills/resolve-issue/SKILL.md
@@ -7,80 +7,44 @@ description: Provides a systematic workflow for resolving GitHub Issues. Use thi
 
 ## Instructions
 
-### Purpose
+### Step 1: Determine Issue Type
 
-Achieve consistent, high-quality problem resolution by determining the GitHub Issue type and applying the appropriate resolution process for each type.
+Check if the Issue has a `type:*` label. If not, determine the type from the title and body:
 
-### Usage Timing
+| Label | Description |
+|-------|-------------|
+| `type:bug` | Fix bugs, errors, or defects |
+| `type:feature` | Add new features |
+| `type:enhancement` | Improve existing features |
+| `type:refactoring` | Code refactoring |
+| `type:documentation` | Update documentation |
+| `type:investigation` | Investigation or analysis tasks |
 
-- When requested to resolve a GitHub Issue
-- When delegated processing by the Issue Auto-resolver
+Default to `type:feature` if unclear.
 
-### Resolution Process
+### Step 2: Follow Type-Specific Instructions
 
-#### Step 1: Determine Issue Type and Apply Label
+Refer to the corresponding file at `{plugin_base_path}/issue-types/<type>.md`:
 
-First, check if the Issue has a `type:*` label.
+- `bug.md` - Bug fixes
+- `feature.md` - New features
+- `enhancement.md` - Feature improvements
+- `refactoring.md` - Code refactoring
+- `documentation.md` - Documentation updates
+- `investigation.md` - Investigation tasks
 
-**If no label is present:**
+### Related Skills
 
-Read the Issue title and body, determine the appropriate type from the following 6 categories, and apply the corresponding label:
+This skill works with the following dev-guidelines skills:
 
-- `type:bug` - Fix bugs, errors, or defects
-- `type:feature` - Add new features
-- `type:investigation` - Investigation or analysis tasks
-- `type:refactoring` - Code refactoring
-- `type:documentation` - Update documentation
-- `type:enhancement` - Improve existing features
-
-If it is difficult to determine, apply `type:feature` by default.
-
-#### Step 2: Follow Detailed Instructions for Each Type
-
-Once the Issue type is determined, refer to the corresponding detailed instruction file at the following times:
-
-**type:bug**
-- **When to refer:** When you need to check specific steps for bug fixing.
-- **Reference file:** `{plugin_base_path}/issue-types/bug.md`
-
-**type:feature**
-- **When to refer:** When you need to check specific steps for implementing new features.
-- **Reference file:** `{plugin_base_path}/issue-types/feature.md`
-
-**type:investigation**
-- **When to refer:** When you need to check specific steps for investigation tasks.
-- **Reference file:** `{plugin_base_path}/issue-types/investigation.md`
-
-**type:refactoring**
-- **When to refer:** When you need to check specific steps for refactoring.
-- **Reference file:** `{plugin_base_path}/issue-types/refactoring.md`
-
-**type:documentation**
-- **When to refer:** When you need to check specific steps for updating documentation.
-- **Reference file:** `{plugin_base_path}/issue-types/documentation.md`
-
-**type:enhancement**
-- **When to refer:** When you need to check specific steps for improving existing features.
-- **Reference file:** `{plugin_base_path}/issue-types/enhancement.md`
-
-### Common Guidelines
-
-Important notes common to all Issue types:
-
-**Code Quality**
-- Check existing code patterns before implementation and maintain consistency.
-- Avoid excessive feature additions or unnecessary refactoring.
-
-**Git Operations**
-- Manage branches according to the implementation workflow (implementation-workflow skill).
-- Keep commit messages clear and concise.
-
-**Creating PRs**
-- Use the `gh pr` command when creating PRs.
-- Write the PR title, comments, and description in Japanese (unless otherwise specified).
-- Include an appropriate summary of changes in the PR description.
+| Skill | When to Use |
+|-------|-------------|
+| `dev-guidelines:implementation-workflow` | Git branch management and testing |
+| `dev-guidelines:pr-description-format` | Creating PRs with `gh pr create` |
+| `dev-guidelines:debugging-process` | Investigating bugs and tracing errors |
+| `dev-guidelines:design-alternatives` | Evaluating implementation approaches |
 
 ### Notes
 
-- `{plugin_base_path}` refers to the base path of the plugin where this skill is installed.
-- When actually referencing files, replace it with the appropriate path.
+- `{plugin_base_path}` refers to the plugin installation directory
+- PR titles and descriptions should be written in Japanese (日本語で記述)

--- a/plugins/issue-resolver/skills/resolve-issue/issue-types/bug.md
+++ b/plugins/issue-resolver/skills/resolve-issue/issue-types/bug.md
@@ -1,41 +1,37 @@
-# type:bug - バグ修正手順
+# type:bug - Bug Fix
 
-## 概要
+## Process
 
-バグ、エラー、不具合の修正を行うための詳細手順です。
+### 1. Understand the Bug
 
-## 実装手順
+- Review symptoms described in the Issue
+- Understand reproduction steps (ask Issue author if unclear)
 
-### 1. バグの内容を確認し、再現手順を理解する
+### 2. Investigate Root Cause
 
-- Issueに記載されているバグの症状を確認する
-- 再現手順が記載されている場合は、その手順を理解する
-- 再現手順が不明確な場合は、コードから推測するか、Issue作成者に確認する
+Use **`dev-guidelines:debugging-process`** skill for systematic investigation:
+- Trace from error messages/stack traces
+- Analyze conditions that trigger the bug
+- Add debug logs if needed
 
-### 2. 関連するコードを調査して原因を特定する
+### 3. Implement Fix
 
-- エラーメッセージやスタックトレースから関連コードを特定する
-- バグが発生する条件や状況を分析する
-- 必要に応じてデバッグログを追加して原因を絞り込む
+- Fix the root cause, not symptoms
+- Verify existing tests still pass
+- Add regression tests as needed
 
-### 3. 修正方法を検討し、実装する
+### 4. Create PR
 
-- 根本原因に対する適切な修正方法を検討する
-- 副作用がないか確認する
-- 既存のテストが壊れないことを確認する
-- 必要に応じて新しいテストを追加する
+Use **`dev-guidelines:pr-description-format`** skill. Include:
+- Bug symptoms
+- Root cause explanation
+- Fix description
+- Test method (if applicable)
 
-### 4. 修正PRを作成する
+Commit message format: `fix: <brief description>`
 
-- コミットメッセージは `fix: <バグの簡潔な説明>` の形式で記載する
-- PRの説明には以下を含める：
-  - バグの症状
-  - 原因の説明
-  - 修正内容
-  - テスト方法（該当する場合）
+## Guidelines
 
-## 注意事項
-
-- バグ修正は最小限の変更に留める
-- 不要なリファクタリングは別のIssueとして分離する
-- セキュリティに関わるバグの場合は特に慎重に対応する
+- Keep changes minimal
+- Separate unrelated refactoring into separate Issues
+- Handle security-related bugs with extra care

--- a/plugins/issue-resolver/skills/resolve-issue/issue-types/documentation.md
+++ b/plugins/issue-resolver/skills/resolve-issue/issue-types/documentation.md
@@ -1,51 +1,48 @@
-# type:documentation - ドキュメント更新手順
+# type:documentation - Documentation Update
 
-## 概要
+## Process
 
-ドキュメントを更新するための詳細手順です。
+### 1. Identify Target Documentation
 
-## 実装手順
+- Identify which documentation needs updating
+- Review current content and identify issues
+- Understand target audience (users, developers, operators, etc.)
 
-### 1. 更新が必要なドキュメントを確認する
+### 2. Gather Accurate Information
 
-- どのドキュメントを更新する必要があるか特定する
-- 現在のドキュメントの内容を確認し、問題点を把握する
-- ドキュメントの対象読者（ユーザー、開発者、運用担当者など）を理解する
+- Verify information from source code
+- Confirm actual behavior (when possible)
+- Collect background from related Issues/PRs
+- Check for inconsistencies with existing documentation
 
-### 2. 正確な情報を収集する
+### 3. Update Documentation
 
-- ソースコードを確認して正確な情報を取得する
-- 実際の動作を確認する（可能な場合）
-- 関連するIssueやPRから背景情報を収集する
-- 既存のドキュメントと矛盾がないか確認する
+- Use clear, concise language
+- Write at appropriate detail level for target audience
+- Include code examples and screenshots as needed
+- Use markdown formatting properly
+- Check for broken links
 
-### 3. ドキュメントを更新する
+### 4. Verify Quality
 
-- 明確で簡潔な表現を使用する
-- 対象読者に適したレベルの詳細さで記載する
-- コード例やスクリーンショットを適宜含める
-- マークダウンの書式を適切に使用する
-- リンク切れがないか確認する
+- Check for typos
+- Verify technical accuracy
+- Ensure natural flow
+- Add cross-references to related documentation as needed
 
-### 4. 読みやすさと正確性を確認する
+### 5. Create PR
 
-- 誤字脱字がないか確認する
-- 技術的な正確性を確認する
-- 文章の流れが自然か確認する
-- 必要に応じて、他のドキュメントへのリンクを追加する
+Use **`dev-guidelines:pr-description-format`** skill. Include:
+- Update purpose
+- Main changes
+- Before/After comparison (if applicable)
 
-### 5. ドキュメント更新PRを作成する
+Commit message format: `docs: <brief description>`
 
-- コミットメッセージは `docs: <更新内容の簡潔な説明>` の形式で記載する
-- PRの説明には以下を含める：
-  - 更新の目的
-  - 主な変更内容
-  - 更新前後の比較（該当する場合）
+## Guidelines
 
-## 注意事項
-
-- ドキュメントは常に最新の実装と一致させる
-- 専門用語は必要に応じて説明を加える
-- 国際化を考慮する場合は、英語と日本語の両方を更新する
-- READMEやチュートリアルなど、重要なドキュメントは特に丁寧に確認する
-- ドキュメントの更新中にコードの問題を見つけた場合は、別のIssueとして報告する
+- Keep documentation in sync with current implementation
+- Add explanations for technical terms as needed
+- Update both English and Japanese when internationalization applies
+- Take extra care with important docs (README, tutorials)
+- Report code issues found during documentation as separate Issues

--- a/plugins/issue-resolver/skills/resolve-issue/issue-types/enhancement.md
+++ b/plugins/issue-resolver/skills/resolve-issue/issue-types/enhancement.md
@@ -1,46 +1,45 @@
-# type:enhancement - 既存機能の改善手順
+# type:enhancement - Feature Enhancement
 
-## 概要
+## Process
 
-既存機能をより良くするための詳細手順です。
+### 1. Understand Current Feature
 
-## 実装手順
+- Understand current behavior
+- Review improvement request in the Issue
+- Clarify improvement goal (performance, usability, maintainability, etc.)
 
-### 1. 改善対象の機能を確認する
+### 2. Plan Approach
 
-- 現在の機能の動作を理解する
-- Issueに記載されている改善要求を確認する
-- 改善の目的（パフォーマンス向上、ユーザビリティ改善、保守性向上など）を明確にする
+Use **`dev-guidelines:design-alternatives`** skill when multiple approaches exist:
+- Evaluate impact of each approach
+- Consider backward compatibility
+- Present options to Issue author if needed
+- Take baseline benchmarks for performance improvements
 
-### 2. 改善方針を検討する
+### 3. Implement
 
-- 複数の改善アプローチがある場合は、それぞれの効果と影響を検討する
-- 既存のユーザーへの影響を考慮する（互換性の維持など）
-- 必要に応じて、改善方針の選択肢をIssue作成者に提示する
-- パフォーマンス改善の場合は、現状のベンチマークを取る
+Follow **`dev-guidelines:implementation-workflow`** skill:
+- Follow existing code style and patterns
+- Maintain consistency with existing features
+- Provide migration path if backward compatibility needed
+- Verify no side effects
+- Add/update tests as needed
 
-### 3. 既存のコードベースのパターンに従って実装する
+### 4. Create PR
 
-- 既存のコードスタイルやパターンに従う
-- 既存の機能との一貫性を保つ
-- 後方互換性が必要な場合は、適切な移行パスを提供する
-- 改善による副作用がないか確認する
-- 必要に応じてテストを追加または更新する
+Use **`dev-guidelines:pr-description-format`** skill. Include:
+- Purpose and background
+- Change summary
+- Improvement effect (quantitative if possible)
+- Before/After comparison
+- Impact on existing features (breaking changes, etc.)
 
-### 4. 改善PRを作成する
+Commit message format: `improve: <brief description>` or `perf: <description>` for performance
 
-- コミットメッセージは `improve: <改善内容の簡潔な説明>` または `perf: <パフォーマンス改善の説明>` の形式で記載する
-- PRの説明には以下を含める：
-  - 改善の目的と背景
-  - 変更内容の概要
-  - 改善の効果（可能であれば定量的に）
-  - Before/Afterの比較
-  - 既存機能への影響（破壊的変更の有無など）
+## Guidelines
 
-## 注意事項
-
-- 改善は段階的に行い、一度に多くを変更しすぎない
-- パフォーマンス改善の場合は、実際にベンチマークで効果を確認する
-- ユーザーインターフェースの改善は、ユーザビリティを慎重に検討する
-- 破壊的変更は極力避け、必要な場合は明確に文書化する
-- 改善の副作用で新しいバグを生まないよう注意する
+- Make improvements incrementally; avoid changing too much at once
+- Verify performance improvements with benchmarks
+- Carefully consider usability for UI changes
+- Avoid breaking changes; document clearly if unavoidable
+- Don't introduce new bugs as side effects

--- a/plugins/issue-resolver/skills/resolve-issue/issue-types/feature.md
+++ b/plugins/issue-resolver/skills/resolve-issue/issue-types/feature.md
@@ -1,43 +1,42 @@
-# type:feature - 新機能追加手順
+# type:feature - New Feature
 
-## 概要
+## Process
 
-新機能を追加するための詳細手順です。
+### 1. Understand Requirements
 
-## 実装手順
+- Review feature requirements in the Issue
+- Clarify expected behavior and I/O
+- Ask Issue author if anything is unclear
 
-### 1. 要求される機能の仕様を理解する
+### 2. Plan Implementation
 
-- Issueに記載されている機能要件を確認する
-- 期待される動作や入出力を明確にする
-- 不明点がある場合はIssue作成者に確認する
+Use **`dev-guidelines:design-alternatives`** skill when multiple approaches exist:
+- Check existing codebase architecture
+- Evaluate pros/cons of each approach
+- Present options to Issue author if needed
+- Leverage existing patterns and libraries
 
-### 2. 実装方針を検討する
+### 3. Implement
 
-- 既存のコードベースのアーキテクチャを確認する
-- 複数の実装方法がある場合は、それぞれの長所・短所を検討する
-- 必要に応じて、実装方針の選択肢をIssue作成者に提示する
-- 既存のパターンやライブラリを活用できないか確認する
+Follow **`dev-guidelines:implementation-workflow`** skill:
+- Follow coding conventions
+- Reuse existing components/utilities
+- Implement proper error handling
+- Add tests as needed
 
-### 3. 既存のコードベースのパターンに従って実装する
+### 4. Create PR
 
-- コーディング規約に従う
-- 既存のコンポーネントやユーティリティを再利用する
-- 適切なエラーハンドリングを実装する
-- 必要に応じてテストを追加する
+Use **`dev-guidelines:pr-description-format`** skill. Include:
+- Feature overview
+- Implementation approach
+- Usage/configuration (if applicable)
+- Test method (if applicable)
 
-### 4. 実装PRを作成する
+Commit message format: `feat: <brief description>`
 
-- コミットメッセージは `feat: <機能の簡潔な説明>` の形式で記載する
-- PRの説明には以下を含める：
-  - 機能の概要
-  - 実装方針の説明
-  - 使用方法や設定方法（該当する場合）
-  - テスト方法（該当する場合）
+## Guidelines
 
-## 注意事項
-
-- 過度に複雑な実装は避け、シンプルに保つ
-- 将来の拡張を想定しすぎた過剰な抽象化は避ける
-- スコープクリープ（機能の肥大化）に注意する
-- 依存関係の追加は必要最小限にする
+- Avoid over-complexity; keep it simple
+- Don't over-abstract for hypothetical future needs
+- Watch for scope creep
+- Minimize new dependencies

--- a/plugins/issue-resolver/skills/resolve-issue/issue-types/investigation.md
+++ b/plugins/issue-resolver/skills/resolve-issue/issue-types/investigation.md
@@ -1,45 +1,52 @@
-# type:investigation - 調査タスク手順
+# type:investigation - Investigation Task
 
-## 概要
+## Process
 
-コードベースやシステムの調査・分析を行うための詳細手順です。
+### 1. Clarify Investigation Scope
 
-## 実装手順
+- Review investigation purpose in the Issue
+- Clarify what to investigate and what information is needed
+- Identify scope (files, directories, system components, etc.)
 
-### 1. 調査対象を明確化する
+### 2. Investigate
 
-- Issueに記載されている調査目的を確認する
-- 何を調べるべきか、どのような情報が必要かを明確にする
-- 調査範囲を特定する（ファイル、ディレクトリ、システムコンポーネントなど）
+Use **`dev-guidelines:debugging-process`** skill for systematic investigation:
+- Read related source code
+- Understand background from commit/PR history
+- Check existing documentation and comments
+- Reference external resources (library docs, etc.) as needed
 
-### 2. 関連するコード、ドキュメント、履歴を調査する
+### 3. Organize Findings
 
-- 関連するソースコードを読む
-- コミット履歴やPR履歴から変更の背景を理解する
-- 既存のドキュメントやコメントを確認する
-- 必要に応じて外部リソース（ライブラリのドキュメントなど）を参照する
+- Structure discovered facts
+- Highlight important findings
+- Use diagrams/tables for visualization as needed
+- Summarize conclusions and recommendations
 
-### 3. 調査結果を整理する
+### 4. Post Results to Issue
 
-- 発見した事実を構造化して整理する
-- 重要な発見事項をハイライトする
-- 必要に応じて図や表を使って視覚化する
-- 結論や推奨事項をまとめる
+Post investigation results as Issue comment with clear, readable format:
 
-### 4. Issueのコメントに調査結果を簡潔にまとめて投稿する
+```
+## 調査概要
+[What was investigated]
 
-- 調査結果を明確で読みやすい形式で記載する
-- 以下の構成を推奨：
-  - **調査概要**: 何を調査したか
-  - **発見事項**: 主要な発見内容
-  - **詳細**: 具体的な調査結果
-  - **結論**: 結論や推奨事項
-- コードへの参照はファイルパスと行番号を含める
-- 長すぎる場合は要点を絞り、詳細は必要に応じて別ドキュメントにまとめる
+## 発見事項
+[Key findings]
 
-## 注意事項
+## 詳細
+[Specific investigation results]
 
-- 調査タスクでは通常、コード変更やPR作成は不要
-- 調査結果に基づいて新しいIssueを作成する必要がある場合は提案する
-- 事実と推測を明確に区別して記載する
-- 調査中に見つけた軽微な問題は、必要に応じて別のIssueとして報告する
+## 結論
+[Conclusions and recommendations]
+```
+
+- Include file path and line numbers for code references
+- Keep it concise; detail can go in separate documents if needed
+
+## Guidelines
+
+- Investigation tasks typically don't require code changes or PRs
+- Propose creating new Issues if findings warrant follow-up work
+- Clearly distinguish facts from speculation
+- Report minor issues found during investigation as separate Issues

--- a/plugins/issue-resolver/skills/resolve-issue/issue-types/refactoring.md
+++ b/plugins/issue-resolver/skills/resolve-issue/issue-types/refactoring.md
@@ -1,44 +1,43 @@
-# type:refactoring - リファクタリング手順
+# type:refactoring - Code Refactoring
 
-## 概要
+## Process
 
-既存の機能を維持しながらコードの構造や品質を改善するための詳細手順です。
+### 1. Understand Target Code
 
-## 実装手順
+- Read and understand the refactoring target
+- Identify problems and improvement opportunities
+- Verify existing tests can guarantee behavior after refactoring
 
-### 1. リファクタリング対象のコードを確認する
+### 2. Plan Approach
 
-- リファクタリング対象のコードを読んで理解する
-- 現在のコードの問題点や改善点を特定する
-- 既存のテストを確認し、リファクタリング後も同じ動作を保証できることを確認する
+Use **`dev-guidelines:design-alternatives`** skill when multiple approaches exist:
+- Clarify refactoring goal (readability, maintainability, performance, etc.)
+- Evaluate impact of each approach
+- Align with existing codebase patterns/style
+- Plan incremental steps for large refactoring
 
-### 2. 改善方針を検討する
+### 3. Implement
 
-- リファクタリングの目的を明確にする（可読性向上、保守性向上、パフォーマンス改善など）
-- 複数のアプローチがある場合は、それぞれの影響を検討する
-- 既存のコードベースのパターンやスタイルに合わせる
-- 大規模なリファクタリングの場合は、段階的に進める計画を立てる
+Follow **`dev-guidelines:implementation-workflow`** skill:
+- Don't change external behavior (API, interfaces)
+- Verify all existing tests pass
+- Add/improve tests as needed
+- Split commits into logical units for easier review
 
-### 3. 既存の機能を維持しながらコードを整理する
+### 4. Create PR
 
-- 外部から見た動作（API、インターフェース）を変更しない
-- 既存のテストがすべてパスすることを確認する
-- 必要に応じてテストを追加または改善する
-- コードレビューしやすいように、論理的な単位でコミットを分ける
+Use **`dev-guidelines:pr-description-format`** skill. Include:
+- Refactoring purpose
+- Change summary
+- Confirmation of no functional changes
+- Before/After comparison (if applicable)
 
-### 4. リファクタリングPRを作成する
+Commit message format: `refactor: <brief description>`
 
-- コミットメッセージは `refactor: <対象の簡潔な説明>` の形式で記載する
-- PRの説明には以下を含める：
-  - リファクタリングの目的
-  - 変更内容の概要
-  - 機能的な変更がないことの確認方法
-  - Before/Afterの比較（該当する場合）
+## Guidelines
 
-## 注意事項
-
-- リファクタリングと機能追加は分離する（同時に行わない）
-- 大規模なリファクタリングは小さな単位に分割して段階的に実施する
-- 既存の動作を変更しないことを最優先にする
-- リファクタリング中に見つけたバグは、別のIssueとして報告する
-- パフォーマンスに影響する変更の場合は、ベンチマークを取る
+- Separate refactoring from feature additions (don't do both at once)
+- Split large refactoring into smaller incremental steps
+- Prioritize preserving existing behavior
+- Report bugs found during refactoring as separate Issues
+- Take benchmarks for performance-impacting changes


### PR DESCRIPTION
## 概要
issue-resolver プラグインのスキルドキュメントを英語化し、dev-guidelines プラグインとの連携を追加

## 変更の背景
- issue-resolver スキルと dev-guidelines スキルの間で重複した内容が存在
- 日本語のままだと一貫性に欠ける
- Skill ツールが workflow で許可されていなかった

## 変更詳細

### issue-resolver スキルのリファクタリング
- 全スキルドキュメントを英語に変換（PR説明やIssueコメントなど日本語が適切な箇所は維持）
- dev-guidelines スキルへの参照を追加:
  - `debugging-process`: バグ調査時
  - `design-alternatives`: 実装方針検討時
  - `implementation-workflow`: 実装時
  - `pr-description-format`: PR作成時
- 重複コンテンツを削除し簡潔化

### workflow の修正
- `claude.yml` の `--allowed-tools` に `Skill(*)` を追加
  - これによりスキルの呼び出しが許可される