### PR TITLE
feat: Add nested if commands to code-like-prompt plugin

### DIFF
--- a/plugins/code-like-prompt/commands/02a-dangling-else-outer.md
+++ b/plugins/code-like-prompt/commands/02a-dangling-else-outer.md
@@ -1,0 +1,23 @@
+---
+description: コード風プロンプト例2a ネストされたif:elseが外側に属する
+argument-hint: "[--condition-a=BOOL] [--condition-b=BOOL]"
+---
+
+Execute the following code. Output only what print() commands specify. Do not show any explanations, code, variables, or other messages.
+
+```
+if ConditionA.value.nil?
+  print("Input: ConditionA (true/false)")
+  ConditionA.value = gets
+end
+if ConditionB.value.nil?
+  print("Input: ConditionB (true/false)")
+  ConditionB.value = gets
+end
+
+if condition_a:
+    if condition_b:
+        print("foo")
+else:
+    print("bar")
+```

--- a/plugins/code-like-prompt/commands/02b-dangling-else-inner.md
+++ b/plugins/code-like-prompt/commands/02b-dangling-else-inner.md
@@ -1,0 +1,23 @@
+---
+description: コード風プロンプト例2b ネストされたif:elseが内側に属する
+argument-hint: "[--condition-a=BOOL] [--condition-b=BOOL]"
+---
+
+Execute the following code. Output only what print() commands specify. Do not show any explanations, code, variables, or other messages.
+
+```
+if ConditionA.value.nil?
+  print("Input: ConditionA (true/false)")
+  ConditionA.value = gets
+end
+if ConditionB.value.nil?
+  print("Input: ConditionB (true/false)")
+  ConditionB.value = gets
+end
+
+if condition_a:
+    if condition_b:
+        print("foo")
+    else:
+        print("bar")
+```

--- a/plugins/code-like-prompt/commands/02c-deep-nesting.md
+++ b/plugins/code-like-prompt/commands/02c-deep-nesting.md
@@ -1,0 +1,49 @@
+---
+description: コード風プロンプト例2c ネストされたif:複雑な5階層ネスト
+argument-hint: "[--level1=BOOL] [--level2=BOOL] [--level3=BOOL] [--level4=BOOL]"
+---
+
+Execute the following code. Output only what print() commands specify. Do not show any explanations, code, variables, or other messages.
+
+```
+if Level1.value.nil?
+  print("Input: Level1 (true/false)")
+  Level1.value = gets
+end
+if Level2.value.nil?
+  print("Input: Level2 (true/false)")
+  Level2.value = gets
+end
+if Level3.value.nil?
+  print("Input: Level3 (true/false)")
+  Level3.value = gets
+end
+if Level4.value.nil?
+  print("Input: Level4 (true/false)")
+  Level4.value = gets
+end
+
+if level1:
+    if level2:
+        if level3:
+            print("foo")
+        else:
+            if level4:
+                print("bar")
+            else:
+                print("baz")
+    else:
+        if level3:
+            if level4:
+                print("qux")
+        else:
+            print("quux")
+else:
+    if level2:
+        print("corge")
+    else:
+        if level3:
+            print("grault")
+        else:
+            print("garply")
+```


### PR DESCRIPTION
## 概要
code-like-promptプラグインにネストされたif文のテストコマンドを追加

## 変更の背景
`.claude/docs/code-like-prompt/02-nested-if.md`の仕様に基づき、Claudeがネストされた条件文を正しく解釈できるかをテストするコマンドを実装した。特に、インデントベースのスコープ判定（dangling else問題）と複雑な深いネストの処理能力を検証する。

## 変更詳細
以下の3つのコマンドを追加：

- `02a-dangling-else-outer.md`: elseが外側のifに属するケースのテスト
  - Pythonスタイルのインデントでelseが外側のifに紐づく場合の動作を検証
  - 引数: `--condition-a`, `--condition-b`

- `02b-dangling-else-inner.md`: elseが内側のifに属するケースのテスト  
  - 02aと対照的に、elseが内側のifに紐づく場合の動作を検証
  - 引数: `--condition-a`, `--condition-b`

- `02c-deep-nesting.md`: 複雑な5階層ネストのテスト
  - elseブランチ内にネストされたif文が含まれる複雑な構造
  - dangling elseパターンが混在する実践的なテストケース
  - 引数: `--level1`, `--level2`, `--level3`, `--level4`

各コマンドは既存の`01-shopping-request.md`と同じフォーマットに従い、擬似コード形式で実装されている。