### PR TITLE
fix: Fix variable assignment in code-like-prompt nested-if commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,36 @@ Automates RBS type definition setup and type error fixing for Ruby projects.
 - Configures .gitignore for generated files
 - Creates Steep configuration based on directory structure
 
+### code-like-prompt Plugin
+
+Provides example commands demonstrating code-like prompt patterns for Claude.
+
+**IMPORTANT**: When working on code-like-prompt plugin (implementation, testing, or debugging), ALWAYS read the relevant documentation in `.claude/docs/code-like-prompt/` first:
+- `.claude/docs/code-like-prompt/overview.md` - Overall concept and philosophy
+- `.claude/docs/code-like-prompt/02-nested-if.md` - Nested if/else pattern documentation
+- `.claude/docs/code-like-prompt/03-loop.md` - Loop pattern documentation
+- `.claude/docs/code-like-prompt/04-pattern-match.md` - Pattern matching documentation
+- Other topic-specific documentation as needed
+
+**Why This Matters**: The documentation contains detailed specifications, design rationale, and expected behavior for each command pattern. Reading it first ensures correct implementation and prevents misunderstandings about command behavior.
+
+**Workflow**:
+1. Read relevant `.claude/docs/code-like-prompt/*.md` documentation
+2. Understand the pattern and design intent
+3. Implement or test the command
+4. Verify behavior matches the specification
+
+**Testing and Deployment**:
+- **IMPORTANT**: Plugin command changes require PR merge and plugin update before testing
+- After merging command changes, Claude Code session restart is required to reload the plugin
+- When finding issues in commands during testing:
+  1. Fix the command files
+  2. Create and merge a PR with the fixes
+  3. Ask the user to restart Claude Code session and update the plugin
+  4. Then perform the actual testing
+
+This workflow is necessary because Claude Code loads plugin commands at session start and doesn't reload them dynamically.
+
 ## Development Workflow
 
 ### Version Management

--- a/plugins/code-like-prompt/commands/02a-dangling-else-outer.md
+++ b/plugins/code-like-prompt/commands/02a-dangling-else-outer.md
@@ -6,13 +6,13 @@ argument-hint: "[--condition-a=BOOL] [--condition-b=BOOL]"
 Execute the following code. Output only what print() commands specify. Do not show any explanations, code, variables, or other messages.
 
 ```
-if ConditionA.value.nil?
-  print("Input: ConditionA (true/false)")
-  ConditionA.value = gets
+if condition_a.nil?
+  print("Input: condition_a (true/false)")
+  condition_a = gets
 end
-if ConditionB.value.nil?
-  print("Input: ConditionB (true/false)")
-  ConditionB.value = gets
+if condition_b.nil?
+  print("Input: condition_b (true/false)")
+  condition_b = gets
 end
 
 if condition_a:

--- a/plugins/code-like-prompt/commands/02b-dangling-else-inner.md
+++ b/plugins/code-like-prompt/commands/02b-dangling-else-inner.md
@@ -6,13 +6,13 @@ argument-hint: "[--condition-a=BOOL] [--condition-b=BOOL]"
 Execute the following code. Output only what print() commands specify. Do not show any explanations, code, variables, or other messages.
 
 ```
-if ConditionA.value.nil?
-  print("Input: ConditionA (true/false)")
-  ConditionA.value = gets
+if condition_a.nil?
+  print("Input: condition_a (true/false)")
+  condition_a = gets
 end
-if ConditionB.value.nil?
-  print("Input: ConditionB (true/false)")
-  ConditionB.value = gets
+if condition_b.nil?
+  print("Input: condition_b (true/false)")
+  condition_b = gets
 end
 
 if condition_a:

--- a/plugins/code-like-prompt/commands/02c-deep-nesting.md
+++ b/plugins/code-like-prompt/commands/02c-deep-nesting.md
@@ -6,21 +6,21 @@ argument-hint: "[--level1=BOOL] [--level2=BOOL] [--level3=BOOL] [--level4=BOOL]"
 Execute the following code. Output only what print() commands specify. Do not show any explanations, code, variables, or other messages.
 
 ```
-if Level1.value.nil?
-  print("Input: Level1 (true/false)")
-  Level1.value = gets
+if level1.nil?
+  print("Input: level1 (true/false)")
+  level1 = gets
 end
-if Level2.value.nil?
-  print("Input: Level2 (true/false)")
-  Level2.value = gets
+if level2.nil?
+  print("Input: level2 (true/false)")
+  level2 = gets
 end
-if Level3.value.nil?
-  print("Input: Level3 (true/false)")
-  Level3.value = gets
+if level3.nil?
+  print("Input: level3 (true/false)")
+  level3 = gets
 end
-if Level4.value.nil?
-  print("Input: Level4 (true/false)")
-  Level4.value = gets
+if level4.nil?
+  print("Input: level4 (true/false)")
+  level4 = gets
 end
 
 if level1:


### PR DESCRIPTION
## 概要
code-like-promptプラグインの02系コマンド（nested-if）において、引数から取得した値を正しく変数に代入するように修正。またCLAUDE.mdにcode-like-promptプラグインのドキュメント参照とテスト・デプロイメントのワークフローを追加。

## 変更の背景
02a, 02b, 02cコマンドの実装において、`ConditionA.value`や`Level1.value`などで引数から値を取得していたが、Pythonコード部分で使用する`condition_a`や`level1`などの変数に代入していなかった。そのため、Claudeが未定義の変数を参照してしまい、期待通りの動作をしていなかった。

また、プラグインコマンドの変更はPRマージ後にセッション再起動が必要という制約があるため、テスト時のワークフローをCLAUDE.mdに明記する必要があった。

## 変更詳細
### コマンドファイルの修正
- `02a-dangling-else-outer.md`: `ConditionA.value` → `condition_a`に直接代入
- `02b-dangling-else-inner.md`: `ConditionA.value` → `condition_a`に直接代入  
- `02c-deep-nesting.md`: `Level1.value` → `level1`に直接代入（level2-4も同様）

変更前の擬似コード:
```ruby
if ConditionA.value.nil?
  ConditionA.value = gets
end
# condition_aが未定義のまま使用
if condition_a:
```

変更後の擬似コード:
```ruby
if condition_a.nil?
  condition_a = gets
end
# condition_aが正しく定義される
if condition_a:
```

### CLAUDE.md更新
- code-like-promptプラグインのセクションを追加
  - ドキュメント参照の重要性（`.claude/docs/code-like-prompt/`）
  - 実装・テスト時のワークフロー
  - テスト・デプロイメントの手順（PR作成→マージ→セッション再起動→テスト）