### PR TITLE
code-like-promptのテストガイドラインと結果を追加

### DIFF
--- a/.claude/docs/code-like-prompt/overview.md
+++ b/.claude/docs/code-like-prompt/overview.md
@@ -79,3 +79,36 @@ Commands are numbered for organization:
 3. Include both "happy path" and edge case testing scenarios
 4. Document expected vs actual behavior for each experiment
 5. Consider adding variant commands that test different interpretations
+
+## Testing Guidelines
+
+### Command Testing Method
+
+**CRITICAL**: When testing code-like-prompt commands, always use `claude` command's non-interactive mode instead of SlashCommand tool.
+
+**Why**: Using SlashCommand tool directly in a session causes command expansion and returns control to the user, preventing continuous automated testing.
+
+**Correct method**:
+```bash
+claude -p "/code-like-prompt:02a-dangling-else-outer --condition-a=true --condition-b=true"
+```
+
+This allows continuous automated testing of multiple patterns without interruption.
+
+### Testing Workflow
+
+1. **Update plugin**: Ensure the plugin is updated and session is restarted
+2. **Run tests systematically**: Use `claude -p` to test all variants with different argument combinations
+3. **Verify output**: Compare actual output against expected behavior in specification docs
+4. **Document results**: Record any deviations or unexpected behaviors
+
+### Test Purpose and Interpretation
+
+**IMPORTANT**: The purpose of code-like-prompt tests is to verify whether Claude can correctly interpret code-like prompts, not to ensure all tests pass.
+
+**Key Points**:
+- These tests evaluate Claude's interpretation capabilities
+- If command specifications and implementations are correct but Claude interprets them incorrectly, this is an **expected and acceptable test outcome**
+- Failed test cases are valuable data points that reveal Claude's current limitations in understanding certain code patterns
+- Examples of challenging patterns: indentation-based scope determination, dangling else problem, complex nested structures
+- All test results (both passes and failures) should be documented to track Claude's interpretation behavior across versions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,22 @@ Provides example commands demonstrating code-like prompt patterns for Claude.
 
 This workflow is necessary because Claude Code loads plugin commands at session start and doesn't reload them dynamically.
 
+**Testing Commands**:
+- **CRITICAL**: When testing code-like-prompt commands, use `claude` command's non-interactive mode instead of SlashCommand tool
+- Using SlashCommand tool directly in the session causes command expansion and returns control to the user, preventing continuous testing
+- Use `claude -p "command"` for non-interactive testing:
+  ```bash
+  claude -p "/code-like-prompt:02a-dangling-else-outer --condition-a=true --condition-b=true"
+  ```
+- This allows continuous automated testing of multiple patterns without interruption
+
+**Test Purpose and Expectations**:
+- **IMPORTANT**: code-like-prompt tests verify whether Claude can correctly interpret code-like prompts
+- The goal is to test Claude's interpretation capabilities, not to ensure all tests pass
+- If command specifications and implementations are correct but Claude interprets them incorrectly, this is an expected test outcome
+- Failed test cases reveal Claude's current limitations in understanding certain code patterns (e.g., indentation-based scope, dangling else problem)
+- Document all test results (both passes and failures) to track Claude's interpretation behavior across versions
+
 ## Development Workflow
 
 ### Version Management


### PR DESCRIPTION
## 概要
code-like-promptプラグインのテスト方法と、02-nested-ifコマンドのテスト結果を文書化

## 変更の背景
- code-like-promptコマンドをSlashCommandツールで直接実行すると、コマンド展開により制御がユーザーに返ってしまい、連続テストができない問題があった
- テストの目的（Claudeの解釈能力を検証するもので、失敗は問題ではない）が文書化されていなかった
- 02-nested-ifの動作確認が完了したが、結果が記録されていなかった

## 変更詳細

### CLAUDE.md
- **Testing Commands**: `claude -p`を使った非対話モードでのテスト方法を追記
- **Test Purpose and Expectations**: テストの目的と、失敗が許容される理由を明記

### .claude/docs/code-like-prompt/overview.md
- **Command Testing Method**: 非対話モードでのテスト方法を詳細に説明
- **Test Purpose and Interpretation**: テストが何を検証するものか、失敗がなぜ問題ではないかを説明

### .claude/docs/code-like-prompt/02-nested-if.md
- **Test Results**: 2025-12-07のテスト結果を追加
  - 02a-dangling-else-outer: 75% (3/4)
  - 02b-dangling-else-inner: 100% (4/4)
  - 02c-deep-nesting: 78% (7/9)
  - 総合: 82% (14/17)
- **Analysis**: 各テストケースの分析と、Claudeの解釈傾向（elseを内側のifに結びつける傾向）を記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)