### PR TITLE
GitHub Actionsワークフローに開発・テスト用の権限を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh label:*),Bash(gh pr:*),Skill(*)"'
+          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh label:*),Bash(gh pr:*),Bash(git add:*),Bash(git push:*),Bash(tree:*),Bash(mkdir:*),Bash(rm:*),Bash(curl:*),Bash(claude:*),WebFetch(domain:github.com),WebFetch(domain:raw.githubusercontent.com),WebFetch(domain:code.claude.com),WebFetch(domain:docs.github.com),SlashCommand(/code-like-prompt:*),Skill(*)"'
 


### PR DESCRIPTION
## 概要
GitHub Actionsのclaude.ymlにallowed_toolsの権限を追加しました。

## 変更の背景
現在のclaude.ymlでは基本的なgh系コマンドとSkillのみが許可されており、実装や動作確認に必要な権限が不足していました。.claude/settings.local.jsonには既に必要な権限が定義されていたため、これらをGitHub Actions環境にも適用します。

## 変更詳細
allowed_toolsに以下の権限を追加しました:

- **Git操作**: `git add:*`, `git push:*` - コミットとプッシュのため
- **ファイル操作**: `mkdir:*`, `rm:*`, `tree:*` - ディレクトリとファイル管理、構造確認のため
- **外部リソース取得**: `curl:*` - 外部リソース取得のため
- **WebFetch**: github.com, raw.githubusercontent.com, code.claude.com, docs.github.com - ドキュメント参照のため
- **Claude Code実行**: `claude:*` - Claude Codeコマンド実行のため
- **プラグインテスト**: `/code-like-prompt:*` - code-like-promptプラグインのテストのため

これにより、GitHub Actions環境でもローカルと同様にコード実装やプラグインテストが可能になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)