### PR TITLE
settings.jsonから削除済みのdev-guidelinesプラグイン参照を除去

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "enabledPlugins": {
+    "plugin-dev@claude-code-plugins": true,
+    "issue-resolver@kokuyouwind-plugins": true
+  },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {
       "source": {
@@ -12,10 +16,5 @@
         "repo": "kokuyouwind/claude-plugins"
       }
     }
-  },
-  "enabledPlugins": {
-    "plugin-dev@claude-code-plugins": true,
-    "dev-guidelines@kokuyouwind-plugins": true,
-    "issue-resolver@kokuyouwind-plugins": true
   }
 }


### PR DESCRIPTION
## 概要
`.claude/settings.json`の`enabledPlugins`から、分割・削除済みの`dev-guidelines`プラグイン参照を除去。

## 変更の背景
dev-guidelinesプラグインは4つの独立プラグインに分割済み（#129）だが、settings.jsonに旧プラグイン名の参照が残っていた。

## 変更詳細
- `enabledPlugins`から`dev-guidelines@kokuyouwind-plugins`を削除
- JSONのキー順序を整理（`enabledPlugins`を先頭に移動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)